### PR TITLE
Added Strobes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,4 +13,4 @@ For maximum compatibility and scalability create the components as scalable vect
 
 [Inkscape]: https://inskscape.org
 
-Please put each unique asset in it's own svg file.  This should facilitate drag-and-drop into Inkscape for inclusion quickly and easily.
+Please put each unique asset in its own svg file.  This should facilitate drag-and-drop into Inkscape for inclusion quickly and easily.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,5 @@
 # Assets needed
 
-- Strobes
-    - Speedlight
-    - Monolight
 - Light Modifiers
     - Brolly
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,12 @@ If you just want to grab the shapes to build your own lighting diagrams, you can
 
 [combined.svg]: https://raw.githubusercontent.com/pixlsus/pixls-lighting-diagram/master/combined.svg
 
+## Contributing
+
+Would you like to contribute? See [Contributing.md](https://github.com/pixlsus/pixls-lighting-diagram/blob/master/CONTRIBUTING.md)
 
 ## Origin of This Lighting Diagram
 
 There were no Free/Libre resources for creating photographic lighting diagrams available until this one came online in 2016. All of the assets hosted here are available under a [Creative Commons, Attribution-ShareAlike](https://creativecommons.org/licenses/by-sa/4.0/) license.
 
 This was prompted by community member Eric Mesa.
-
-## Contributing
-
-Would you like to contribute? See [Contributing.md](https://github.com/pixlsus/pixls-lighting-diagram/blob/master/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -5,14 +5,19 @@ Assets to generate lighting diagrams and setups like this one:
 
 They can be used to plan a photoshoot ahead of time or to communicate your setup to other photographers. Here is an example of a professional photographer, Gavin Hooey, using lighting diagrams to show viewers how his lights are setup: https://www.youtube.com/watch?v=xUCQQ8Cp9h4 . 
 
-There were no Free/Libre resources for creating photographic lighting diagrams available until this one came online in 2016. All of the assets hosted here are available under a [Creative Commons, Attribution-ShareAlike](https://creativecommons.org/licenses/by-sa/4.0/) license.
-
-This was prompted by community member Eric Mesa.
-
-Would you like to contribute? See [Contributing.md](https://github.com/pixlsus/pixls-lighting-diagram/blob/master/CONTRIBUTING.md)
-
 ## Assets Downloading
 
 If you just want to grab the shapes to build your own lighting diagrams, you can just grab the [combined.svg][] file (Right-click, Save link as...).  It _should_ contain all of the assets.
 
 [combined.svg]: https://raw.githubusercontent.com/pixlsus/pixls-lighting-diagram/master/combined.svg
+
+
+## Origin of This Lighting Diagram
+
+There were no Free/Libre resources for creating photographic lighting diagrams available until this one came online in 2016. All of the assets hosted here are available under a [Creative Commons, Attribution-ShareAlike](https://creativecommons.org/licenses/by-sa/4.0/) license.
+
+This was prompted by community member Eric Mesa.
+
+## Contributing
+
+Would you like to contribute? See [Contributing.md](https://github.com/pixlsus/pixls-lighting-diagram/blob/master/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@ Assets to generate lighting diagrams and setups like this one:
 
 ![example lighting setup](https://raw.githubusercontent.com/djotaku/pixls-lighting-diagram/master/examples/portrait_lighting_setup.png)
 
+They can be used to plan a photoshoot ahead of time or to communicate your setup to other photographers. Here is an example of a professional photographer, Gavin Hooey, using lighting diagrams to show viewers how his lights are setup: https://www.youtube.com/watch?v=xUCQQ8Cp9h4 . 
+
 There were no Free/Libre resources for creating photographic lighting diagrams available until this one came online in 2016. All of the assets hosted here are available under a [Creative Commons, Attribution-ShareAlike](https://creativecommons.org/licenses/by-sa/4.0/) license.
 
 This was prompted by community member Eric Mesa.
 
-Would you like to contribute? See [Contributing.md](https://github.com/djotaku/pixls-lighting-diagram/blob/master/CONTRIBUTING.md)
+Would you like to contribute? See [Contributing.md](https://github.com/pixlsus/pixls-lighting-diagram/blob/master/CONTRIBUTING.md)
 
 ## Assets Downloading
 

--- a/combined.svg
+++ b/combined.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -10,154 +8,155 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="210mm"
-   height="297mm"
-   viewBox="0 0 744.09448819 1052.3622047"
-   id="svg2"
+   sodipodi:docname="combined.svg"
+   inkscape:version="1.0beta2 (unknown)"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="combined.svg">
+   id="svg2"
+   viewBox="0 0 744.09448819 1052.3622047"
+   height="297mm"
+   width="210mm">
   <defs
      id="defs4">
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4836">
+       id="linearGradient4836"
+       inkscape:collect="always">
       <stop
-         style="stop-color:#b3b3b3;stop-opacity:1;"
+         id="stop4838"
          offset="0"
-         id="stop4838" />
+         style="stop-color:#b3b3b3;stop-opacity:1;" />
       <stop
-         style="stop-color:#b3b3b3;stop-opacity:0;"
+         id="stop4840"
          offset="1"
-         id="stop4840" />
+         style="stop-color:#b3b3b3;stop-opacity:0;" />
     </linearGradient>
+    <inkscape:perspective
+       id="perspective4142"
+       inkscape:persp3d-origin="281.60529 : 441.53518 : 1"
+       inkscape:vp_z="659.7477 : 239.17323 : 1"
+       inkscape:vp_y="1.1625214e-006 : 1000 : 0"
+       inkscape:vp_x="-30.68594 : 248.0315 : 1"
+       sodipodi:type="inkscape:persp3d" />
     <inkscape:perspective
        sodipodi:type="inkscape:persp3d"
        inkscape:vp_x="-30.68594 : 248.0315 : 1"
        inkscape:vp_y="1.1625214e-006 : 1000 : 0"
        inkscape:vp_z="659.7477 : 239.17323 : 1"
        inkscape:persp3d-origin="281.60529 : 441.53518 : 1"
-       id="perspective4142" />
-    <inkscape:perspective
-       id="perspective4142-3"
-       inkscape:persp3d-origin="281.60529 : 441.53518 : 1"
-       inkscape:vp_z="659.7477 : 239.17323 : 1"
-       inkscape:vp_y="1.1625214e-006 : 1000 : 0"
-       inkscape:vp_x="-30.68594 : 248.0315 : 1"
-       sodipodi:type="inkscape:persp3d" />
+       id="perspective4142-3" />
     <linearGradient
-       gradientTransform="translate(-52.38242,-4.2857143)"
-       gradientUnits="userSpaceOnUse"
-       y2="605.79462"
-       x2="203.06804"
-       y1="401.43369"
-       x1="557.39703"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4836"
        id="linearGradient4494"
-       xlink:href="#linearGradient4836"
-       inkscape:collect="always" />
-    <inkscape:perspective
-       id="perspective4142-7"
-       inkscape:persp3d-origin="281.60529 : 441.53518 : 1"
-       inkscape:vp_z="659.7477 : 239.17323 : 1"
-       inkscape:vp_y="1.1625214e-006 : 1000 : 0"
-       inkscape:vp_x="-30.68594 : 248.0315 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <radialGradient
+       x1="557.39703"
+       y1="401.43369"
+       x2="203.06804"
+       y2="605.79462"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.6464086,0,0,1.6207397,-773.68155,192.61129)"
-       r="2.8130922"
-       fy="475.44604"
-       fx="1193.7875"
-       cy="475.44604"
-       cx="1193.7875"
-       id="radialGradient4533"
+       gradientTransform="translate(-52.38242,-4.2857143)" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="-30.68594 : 248.0315 : 1"
+       inkscape:vp_y="1.1625214e-006 : 1000 : 0"
+       inkscape:vp_z="659.7477 : 239.17323 : 1"
+       inkscape:persp3d-origin="281.60529 : 441.53518 : 1"
+       id="perspective4142-7" />
+    <radialGradient
+       inkscape:collect="always"
        xlink:href="#linearGradient4836"
-       inkscape:collect="always" />
+       id="radialGradient4533"
+       cx="1193.7875"
+       cy="475.44604"
+       fx="1193.7875"
+       fy="475.44604"
+       r="2.8130922"
+       gradientTransform="matrix(1.6464086,0,0,1.6207397,-773.68155,192.61129)"
+       gradientUnits="userSpaceOnUse" />
     <linearGradient
-       id="linearGradient4172"
-       inkscape:collect="always">
+       inkscape:collect="always"
+       id="linearGradient4172">
       <stop
-         id="stop4174"
+         style="stop-color:#a0a0a0;stop-opacity:1;"
          offset="0"
-         style="stop-color:#a0a0a0;stop-opacity:1;" />
+         id="stop4174" />
       <stop
-         id="stop4176"
+         style="stop-color:#a0a0a0;stop-opacity:0;"
          offset="1"
-         style="stop-color:#a0a0a0;stop-opacity:0;" />
+         id="stop4176" />
     </linearGradient>
     <radialGradient
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,1.0060909,212.51535,543.28513)"
-       r="71.005104"
-       fy="78.030426"
-       fx="77.316605"
-       cy="78.030426"
-       cx="77.316605"
-       id="radialGradient4190"
-       xlink:href="#linearGradient4172"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="340.79028"
-       x2="452.505"
-       y1="340.79028"
-       x1="391.50836"
-       id="linearGradient4167"
-       xlink:href="#linearGradient4836"
        inkscape:collect="always"
-       gradientTransform="translate(-71.72083,-65.659914)" />
-    <radialGradient
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,1.0060909,241.05642,361.88691)"
-       r="71.005104"
-       fy="78.030426"
-       fx="77.316605"
-       cy="78.030426"
+       xlink:href="#linearGradient4172"
+       id="radialGradient4190"
        cx="77.316605"
+       cy="78.030426"
+       fx="77.316605"
+       fy="78.030426"
+       r="71.005104"
+       gradientTransform="matrix(1,0,0,1.0060909,212.51535,543.28513)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="translate(-71.72083,-65.659914)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4836"
+       id="linearGradient4167"
+       x1="391.50836"
+       y1="340.79028"
+       x2="452.505"
+       y2="340.79028"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4172"
        id="radialGradient4190-0"
-       xlink:href="#linearGradient4172"
-       inkscape:collect="always" />
-    <radialGradient
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,1.0015327,0,-0.34034288)"
-       r="71.520386"
-       fy="222.04796"
-       fx="76.797615"
-       cy="222.04796"
-       cx="76.797615"
-       id="radialGradient4188"
-       xlink:href="#linearGradient4172"
-       inkscape:collect="always" />
-    <radialGradient
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,1.0060909,0,-0.47527586)"
-       r="71.005104"
-       fy="78.030426"
-       fx="77.316605"
-       cy="78.030426"
        cx="77.316605"
-       id="radialGradient4190-5"
+       cy="78.030426"
+       fx="77.316605"
+       fy="78.030426"
+       r="71.005104"
+       gradientTransform="matrix(1,0,0,1.0060909,241.05642,361.88691)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
        xlink:href="#linearGradient4172"
-       inkscape:collect="always" />
+       id="radialGradient4188"
+       cx="76.797615"
+       cy="222.04796"
+       fx="76.797615"
+       fy="222.04796"
+       r="71.520386"
+       gradientTransform="matrix(1,0,0,1.0015327,0,-0.34034288)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4172"
+       id="radialGradient4190-5"
+       cx="77.316605"
+       cy="78.030426"
+       fx="77.316605"
+       fy="78.030426"
+       r="71.005104"
+       gradientTransform="matrix(1,0,0,1.0060909,0,-0.47527586)"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="0.98994949"
-     inkscape:cx="473.24789"
-     inkscape:cy="428.88228"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     inkscape:window-maximized="1"
+     inkscape:window-y="0"
+     inkscape:window-x="1920"
+     inkscape:window-height="1411"
+     inkscape:window-width="2560"
      showgrid="false"
-     inkscape:window-width="1920"
-     inkscape:window-height="1142"
-     inkscape:window-x="-4"
-     inkscape:window-y="-4"
-     inkscape:window-maximized="1" />
+     inkscape:current-layer="layer1"
+     inkscape:document-units="px"
+     inkscape:cy="619.3695"
+     inkscape:cx="345.90414"
+     inkscape:zoom="1.28"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
   <metadata
      id="metadata7">
     <rdf:RDF>
@@ -171,55 +170,37 @@
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Layer 1"
+     id="layer1"
      inkscape:groupmode="layer"
-     id="layer1">
+     inkscape:label="Layer 1">
     <g
-       id="layer1-0"
+       transform="translate(7.1948667,-19.66656)"
        inkscape:label="Layer 1"
-       transform="translate(7.1948667,-19.66656)">
+       id="layer1-0">
       <path
-         sodipodi:nodetypes="ccscsc"
-         inkscape:connector-curvature="0"
-         id="path5562"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.44090998;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m 64.285709,75.80703 c 0,0 14.409099,0 14.409099,36.02274 l 0,215.77627 417.863882,0 0,-222.98082 c 0,-28.81819 14.4091,-28.81819 14.4091,-28.81819"
-         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.44090998;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         id="path5562"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccscsc" />
       <rect
-         y="61.397942"
-         x="64.285698"
-         height="14.4091"
-         width="446.68207"
-         id="rect5560"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      <rect
-         y="65.319496"
-         x="53.271339"
-         height="6.5659914"
-         width="468.71078"
-         id="rect6134"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      <path
-         inkscape:transform-center-y="15.48821"
-         transform="matrix(0.8660254,0.5,-0.5,0.8660254,42.546472,-16.325391)"
-         inkscape:transform-center-x="-2.7127746"
-         d="m 82.486829,19.492164 c 3.277793,1.892435 -24.447008,44.442312 -24.447008,48.227181 10e-7,3.784869 27.724806,46.334745 24.447013,48.227175 -3.277793,1.89244 -26.264667,-43.392883 -29.54246,-45.285317 -3.277793,-1.892434 -53.9894674,0.843014 -53.9894675,-2.941855 -2e-7,-3.784869 50.7116745,-1.049426 53.9894675,-2.941861 3.277793,-1.892434 26.264662,-47.177757 29.542455,-45.285323 z"
-         inkscape:randomized="0"
-         inkscape:rounded="0.07"
-         inkscape:flatsided="false"
-         sodipodi:arg2="-4.8803402e-008"
-         sodipodi:arg1="-1.0471976"
-         sodipodi:r2="3.3969648"
-         sodipodi:r1="55.68795"
-         sodipodi:cy="67.719345"
-         sodipodi:cx="54.642857"
-         sodipodi:sides="3"
-         id="path6136"
          style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         sodipodi:type="star" />
+         id="rect5560"
+         width="446.68207"
+         height="14.4091"
+         x="64.285698"
+         y="61.397942" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="rect6134"
+         width="468.71078"
+         height="6.5659914"
+         x="53.271339"
+         y="65.319496" />
       <path
          sodipodi:type="star"
          style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         id="path6138"
+         id="path6136"
          sodipodi:sides="3"
          sodipodi:cx="54.642857"
          sodipodi:cy="67.719345"
@@ -232,871 +213,1035 @@
          inkscape:randomized="0"
          d="m 82.486829,19.492164 c 3.277793,1.892435 -24.447008,44.442312 -24.447008,48.227181 10e-7,3.784869 27.724806,46.334745 24.447013,48.227175 -3.277793,1.89244 -26.264667,-43.392883 -29.54246,-45.285317 -3.277793,-1.892434 -53.9894674,0.843014 -53.9894675,-2.941855 -2e-7,-3.784869 50.7116745,-1.049426 53.9894675,-2.941861 3.277793,-1.892434 26.264662,-47.177757 29.542455,-45.285323 z"
          inkscape:transform-center-x="-2.7127746"
-         transform="matrix(0.8660254,0.5,-0.5,0.8660254,505.40362,-16.325391)"
+         transform="matrix(0.8660254,0.5,-0.5,0.8660254,42.546472,-16.325391)"
          inkscape:transform-center-y="15.48821" />
+      <path
+         inkscape:transform-center-y="15.48821"
+         transform="matrix(0.8660254,0.5,-0.5,0.8660254,505.40362,-16.325391)"
+         inkscape:transform-center-x="-2.7127746"
+         d="m 82.486829,19.492164 c 3.277793,1.892435 -24.447008,44.442312 -24.447008,48.227181 10e-7,3.784869 27.724806,46.334745 24.447013,48.227175 -3.277793,1.89244 -26.264667,-43.392883 -29.54246,-45.285317 -3.277793,-1.892434 -53.9894674,0.843014 -53.9894675,-2.941855 -2e-7,-3.784869 50.7116745,-1.049426 53.9894675,-2.941861 3.277793,-1.892434 26.264662,-47.177757 29.542455,-45.285323 z"
+         inkscape:randomized="0"
+         inkscape:rounded="0.07"
+         inkscape:flatsided="false"
+         sodipodi:arg2="-4.8803402e-008"
+         sodipodi:arg1="-1.0471976"
+         sodipodi:r2="3.3969648"
+         sodipodi:r1="55.68795"
+         sodipodi:cy="67.719345"
+         sodipodi:cx="54.642857"
+         sodipodi:sides="3"
+         id="path6138"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         sodipodi:type="star" />
     </g>
     <g
-       id="layer1-7"
+       transform="matrix(0.53691623,0,0,0.53691623,439.32642,383.8607)"
        inkscape:label="Layer 1"
-       transform="matrix(0.53691623,0,0,0.53691623,439.32642,383.8607)">
+       id="layer1-7">
       <g
          id="g6174">
         <g
-           id="g4356-4"
-           transform="matrix(0.26514641,0,0,0.26514641,-186.57627,-158.04605)">
+           transform="matrix(0.26514641,0,0,0.26514641,-186.57627,-158.04605)"
+           id="g4356-4">
           <rect
-             rx="57.152275"
-             ry="65.993614"
-             y="786.6142"
-             x="1043.3219"
-             height="106.29921"
-             width="61.371967"
-             id="rect4358-7"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-          <rect
-             ry="49.49522"
-             y="822.04724"
-             x="797.83441"
-             height="79.724411"
-             width="306.85944"
-             id="rect4360-5"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-             rx="49.49522" />
-          <rect
-             rx="114.30438"
-             ry="32.996811"
-             y="706.88977"
-             x="874.54926"
-             height="159.44882"
-             width="122.74376"
-             id="rect4362-8"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-          <circle
-             r="29.565052"
-             cy="860.8952"
-             cx="844.63135"
-             id="circle4364-4"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#242424;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-          <circle
              style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-             id="circle4366-3"
-             cx="1028.2028"
-             cy="860.8952"
-             r="22.422195" />
+             id="rect4358-7"
+             width="61.371967"
+             height="106.29921"
+             x="1043.3219"
+             y="786.6142"
+             ry="65.993614"
+             rx="57.152275" />
+          <rect
+             rx="49.49522"
+             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+             id="rect4360-5"
+             width="306.85944"
+             height="79.724411"
+             x="797.83441"
+             y="822.04724"
+             ry="49.49522" />
+          <rect
+             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+             id="rect4362-8"
+             width="122.74376"
+             height="159.44882"
+             x="874.54926"
+             y="706.88977"
+             ry="32.996811"
+             rx="114.30438" />
           <circle
-             r="13.136481"
-             cy="840.18091"
-             cx="1068.917"
+             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#242424;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+             id="circle4364-4"
+             cx="844.63135"
+             cy="860.8952"
+             r="29.565052" />
+          <circle
+             r="22.422195"
+             cy="860.8952"
+             cx="1028.2028"
+             id="circle4366-3"
+             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+          <circle
+             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
              id="circle4368-9"
-             style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+             cx="1068.917"
+             cy="840.18091"
+             r="13.136481" />
         </g>
       </g>
     </g>
     <g
-       id="layer1-2"
+       transform="matrix(0.64528118,0,0,0.64528118,81.603553,359.92455)"
        inkscape:label="Layer 1"
-       transform="matrix(0.64528118,0,0,0.64528118,81.603553,359.92455)">
+       id="layer1-2">
       <g
-         style="stroke-width:1.52315819;stroke-miterlimit:4;stroke-dasharray:none"
+         transform="matrix(1.3130612,0,0,1.3130612,-430.39455,-938.26812)"
          id="g4342-1"
-         transform="matrix(1.3130612,0,0,1.3130612,-430.39455,-938.26812)">
+         style="stroke-width:1.52315819;stroke-miterlimit:4;stroke-dasharray:none">
         <path
-           inkscape:connector-curvature="0"
-           id="path4344-2"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.52315819;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="m 429.54518,768.75271 122.8597,0 92.14478,17.85202 0,17.85202 -92.14478,17.85202 -122.8597,0 -92.14478,-17.85202 0,-17.85202 z"
-           style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.52315819;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           id="path4344-2"
+           inkscape:connector-curvature="0" />
         <path
-           inkscape:connector-curvature="0"
-           id="path4346-8"
-           d="m 429.66112,822.30877 15.285,44.02981 92.05782,0 15.40094,-44.02981 z"
+           sodipodi:nodetypes="ccccc"
            style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.52315819;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 429.66112,822.30877 15.285,44.02981 92.05782,0 15.40094,-44.02981 z"
+           id="path4346-8"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:#323232;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.52315819;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 537.00394,866.33858 15.4879,-44.1653 92.05782,-17.71653 -46.17384,37.07868 z"
+           id="path4348-0"
+           inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccccc" />
         <path
-           sodipodi:nodetypes="ccccc"
-           inkscape:connector-curvature="0"
-           id="path4348-0"
-           d="m 537.00394,866.33858 15.4879,-44.1653 92.05782,-17.71653 -46.17384,37.07868 z"
-           style="fill:#323232;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.52315819;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           inkscape:connector-curvature="0"
-           id="path4350-9"
+           style="fill:#323232;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.52315819;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="m 444.94612,866.33858 c 0,-3.5433 -15.40094,-44.02981 -15.40094,-44.02981 l -92.14478,-17.85202 46.17384,37.07868 z"
-           style="fill:#323232;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.52315819;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           id="path4350-9"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
       </g>
       <g
          id="g6174-0">
         <g
-           transform="translate(-430.32498,171.72593)"
-           id="g4175">
+           id="g4175"
+           transform="translate(-430.32498,171.72593)">
           <g
-             transform="matrix(1.3130612,0,0,1.3130612,-0.06956568,-938.26812)"
-             id="g6114">
+             id="g6114"
+             transform="matrix(1.3130612,0,0,1.3130612,-0.06956568,-938.26812)">
             <path
-               style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.52315819;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-               d="m 429.54518,768.75271 122.8597,0 92.14478,17.85202 0,17.85202 -92.14478,17.85202 -122.8597,0 -92.14478,-17.85202 0,-17.85202 z"
+               inkscape:connector-curvature="0"
                id="path6116"
-               inkscape:connector-curvature="0" />
+               d="m 429.54518,768.75271 122.8597,0 92.14478,17.85202 0,17.85202 -92.14478,17.85202 -122.8597,0 -92.14478,-17.85202 0,-17.85202 z"
+               style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.52315819;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            <path
+               inkscape:connector-curvature="0"
+               id="path6118"
+               d="m 429.66112,822.30877 15.285,44.02981 92.05782,0 15.40094,-44.02981 z"
+               style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+               sodipodi:nodetypes="ccccc" />
             <path
                sodipodi:nodetypes="ccccc"
-               style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-               d="m 429.66112,822.30877 15.285,44.02981 92.05782,0 15.40094,-44.02981 z"
-               id="path6118"
-               inkscape:connector-curvature="0" />
-            <path
-               style="fill:#323232;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-               d="m 537.00394,866.33858 15.4879,-44.1653 92.05782,-17.71653 -46.17384,37.07868 z"
+               inkscape:connector-curvature="0"
                id="path6120"
-               inkscape:connector-curvature="0"
-               sodipodi:nodetypes="ccccc" />
+               d="m 537.00394,866.33858 15.4879,-44.1653 92.05782,-17.71653 -46.17384,37.07868 z"
+               style="fill:#323232;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
             <path
-               style="fill:#323232;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.52315819;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-               d="m 444.94612,866.33858 c 0,-3.5433 -15.40094,-44.02981 -15.40094,-44.02981 l -92.14478,-17.85202 46.17384,37.07868 z"
-               id="path6122"
+               sodipodi:nodetypes="ccccc"
                inkscape:connector-curvature="0"
-               sodipodi:nodetypes="ccccc" />
+               id="path6122"
+               d="m 444.94612,866.33858 c 0,-3.5433 -15.40094,-44.02981 -15.40094,-44.02981 l -92.14478,-17.85202 46.17384,37.07868 z"
+               style="fill:#323232;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.52315819;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
           </g>
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path6124"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              d="m 644.61078,71.151236 0,70.978914"
-             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+             id="path6124"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             d="m 667.03406,71.151236 0,70.978914"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path6126"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 667.03406,71.151236 0,70.978914"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path6128"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              d="m 689.45734,71.151236 0,70.978914"
-             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+             id="path6128"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             d="m 711.88062,71.865522 0,70.978918"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path6130"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 711.88062,71.865522 0,70.978918"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path6132"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              d="m 734.30389,72.936951 0,66.642519"
-             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+             id="path6132"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             d="m 756.72717,77.245352 0,58.134148"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path6134"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 756.72717,77.245352 0,58.134148"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path6136-6"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              d="m 779.15045,81.589612 0,49.445628"
-             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+             id="path6136-6"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             d="m 801.57373,85.933872 0,40.699518"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path6138-8"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 801.57373,85.933872 0,40.699518"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path6140"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              d="m 823.99701,90.278131 0,32.039899"
-             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             sodipodi:nodetypes="cc"
+             id="path6140"
              inkscape:connector-curvature="0"
-             id="path6144"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              d="m 465.22455,90.278099 0,32.068661"
-             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+             id="path6144"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             d="m 487.64783,85.933839 0,40.757181"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path6146"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 487.64783,85.933839 0,40.757181"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path6148"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              d="m 510.07111,81.58958 0,49.4457"
-             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+             id="path6148"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             d="m 532.49438,77.245322 0,58.134208"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path6150"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 532.49438,77.245322 0,58.134208"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path6152"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              d="m 554.91766,72.901062 0,66.822728"
-             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+             id="path6152"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             d="m 577.34094,71.151236 0,74.579234"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path6154"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 577.34094,71.151236 0,74.579234"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path6156"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              d="m 599.76422,71.151236 0,74.936374"
-             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+             id="path6156"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             d="m 622.1875,71.151236 0,74.222084"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path6158"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 622.1875,71.151236 0,74.222084"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path6162"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              d="m 539.26478,75.933494 210.69183,0"
-             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+             id="path6162"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             d="m 483.31563,86.773154 322.59013,0"
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
              id="path6164"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc" />
+             d="m 483.31563,86.773154 322.59013,0"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
           <path
-             sodipodi:nodetypes="cc"
-             inkscape:connector-curvature="0"
-             id="path6166"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              d="m 442.95781,97.612815 403.30577,0"
-             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             d="m 442.95781,108.45248 403.30577,0"
-             id="path6168"
+             id="path6166"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="cc" />
           <path
              sodipodi:nodetypes="cc"
              inkscape:connector-curvature="0"
-             id="path6170"
-             d="m 449.45787,119.29214 390.26212,0"
+             id="path6168"
+             d="m 442.95781,108.45248 403.30577,0"
              style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
           <path
              style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             d="m 505.40774,130.1318 278.40592,0"
-             id="path6172"
+             d="m 449.45787,119.29214 390.26212,0"
+             id="path6170"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="cc" />
+          <path
+             sodipodi:nodetypes="cc"
+             inkscape:connector-curvature="0"
+             id="path6172"
+             d="m 505.40774,130.1318 278.40592,0"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         </g>
       </g>
     </g>
     <g
-       id="layer1-3"
+       transform="matrix(0.41411152,0,0,0.41411152,378.70869,326.99272)"
        inkscape:label="Layer 1"
-       transform="matrix(0.41411152,0,0,0.41411152,378.70869,326.99272)">
+       id="layer1-3">
       <g
          id="g6174-06">
         <g
            id="g6866">
           <g
-             transform="translate(-144.24978,-251.73001)"
-             id="g6872">
+             id="g6872"
+             transform="translate(-144.24978,-251.73001)">
             <path
-               inkscape:connector-curvature="0"
-               id="path6822"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#191919;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.98473239;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.98039216;marker:none;enable-background:accumulate"
                d="m 293.67969,275.94922 a 150,45.892853 0 0 0 -123.07031,45.12695 150,45.892853 0 0 0 112.5996,44.38477 55.55584,55.55584 0 0 1 -18.15429,-40.99219 55.55584,55.55584 0 0 1 28.625,-48.51953 z m 53.98437,0.0215 a 55.55584,55.55584 0 0 1 28.50196,48.49805 55.55584,55.55584 0 0 1 -18.17383,41.01563 150,45.892853 0 0 0 112.61719,-44.40821 150,45.892853 0 0 0 -122.94532,-45.10547 z"
-               style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#191919;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.98473239;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.98039216;marker:none;enable-background:accumulate" />
+               id="path6822"
+               inkscape:connector-curvature="0" />
             <g
-               inkscape:transform-center-x="-0.00390625"
-               inkscape:transform-center-y="9.734437"
+               style="fill:#323232;fill-opacity:1"
                id="g6862"
-               style="fill:#323232;fill-opacity:1">
+               inkscape:transform-center-y="9.734437"
+               inkscape:transform-center-x="-0.00390625">
               <circle
-                 style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#323232;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-                 id="path6839"
-                 cx="320.60989"
+                 r="50"
                  cy="324.4686"
-                 r="50" />
+                 cx="320.60989"
+                 id="path6839"
+                 style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#323232;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
               <path
-                 sodipodi:type="star"
-                 style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#323232;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-                 id="path6849"
-                 sodipodi:sides="3"
-                 sodipodi:cx="320.60989"
-                 sodipodi:cy="372.78592"
-                 sodipodi:r1="21.146959"
-                 sodipodi:r2="10.57348"
-                 sodipodi:arg1="1.5707963"
-                 sodipodi:arg2="2.6179939"
-                 inkscape:flatsided="true"
-                 inkscape:rounded="0.1"
-                 inkscape:randomized="0"
+                 inkscape:transform-center-y="5.2867398"
                  d="m 320.60989,393.93288 c -3.66276,0 -20.14518,-28.5484 -18.3138,-31.72044 1.83138,-3.17204 34.79623,-3.17204 36.62761,0 1.83138,3.17204 -14.65104,31.72044 -18.31381,31.72044 z"
-                 inkscape:transform-center-y="5.2867398" />
+                 inkscape:randomized="0"
+                 inkscape:rounded="0.1"
+                 inkscape:flatsided="true"
+                 sodipodi:arg2="2.6179939"
+                 sodipodi:arg1="1.5707963"
+                 sodipodi:r2="10.57348"
+                 sodipodi:r1="21.146959"
+                 sodipodi:cy="372.78592"
+                 sodipodi:cx="320.60989"
+                 sodipodi:sides="3"
+                 id="path6849"
+                 style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#323232;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+                 sodipodi:type="star" />
             </g>
           </g>
         </g>
       </g>
     </g>
     <g
-       id="layer1-77"
+       transform="matrix(0.38778993,0,0,0.38778993,83.46791,318.33749)"
        inkscape:label="Layer 1"
-       transform="matrix(0.38778993,0,0,0.38778993,83.46791,318.33749)">
+       id="layer1-77">
       <g
-         transform="translate(-257.80327,-531.35166)"
-         id="g4198-6">
+         id="g4198-6"
+         transform="translate(-257.80327,-531.35166)">
         <path
-           style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 276.17346,574.01575 337.54533,0 -30.68594,-17.71654 -276.17345,0 z"
+           inkscape:connector-curvature="0"
            id="path4194-4"
-           inkscape:connector-curvature="0" />
+           d="m 276.17346,574.01575 337.54533,0 -30.68594,-17.71654 -276.17345,0 z"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <path
-           style="fill:#191919;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.58889103;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 275.97601,573.80362 107.52637,106.10188 122.8873,0 107.52638,-106.10188 -337.94005,0"
+           inkscape:connector-curvature="0"
            id="path4196-0"
-           inkscape:connector-curvature="0" />
+           d="m 275.97601,573.80362 107.52637,106.10188 122.8873,0 107.52638,-106.10188 -337.94005,0"
+           style="fill:#191919;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.58889103;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <g
          id="g6067">
         <path
-           inkscape:connector-curvature="0"
-           id="path5377"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="m 389.79876,42.66409 337.54533,0 -30.68594,-17.71654 -276.17345,0 z"
-           style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           id="path5377"
+           inkscape:connector-curvature="0" />
         <path
-           inkscape:connector-curvature="0"
-           id="path5379"
+           style="fill:#191919;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.58889103;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="m 389.60131,42.45196 107.52637,106.10188 122.8873,0 107.52638,-106.10188 -337.94005,0"
-           style="fill:#191919;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.58889103;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           id="path5379"
+           inkscape:connector-curvature="0" />
         <path
-           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 558.57141,24.94755 0,17.71654"
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
            id="path5381"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path5385"
-           d="M 584.87357,24.94755 587.646,42.45196"
-           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 611.10804,24.94755 5.75645,17.50441"
-           id="path5387"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path5389"
-           d="m 637.19245,24.94755 8.91894,17.50441"
-           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 660.91788,24.94755 12.71769,17.50441"
-           id="path5391"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path5393"
-           d="m 688.35431,24.94755 17.50441,17.50441"
-           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path5424"
            d="m 558.57141,24.94755 0,17.71654"
            style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <path
            style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 532.26925,24.94755 -2.77243,17.50441"
+           d="M 584.87357,24.94755 587.646,42.45196"
+           id="path5385"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path5387"
+           d="m 611.10804,24.94755 5.75645,17.50441"
+           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 637.19245,24.94755 8.91894,17.50441"
+           id="path5389"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path5391"
+           d="m 660.91788,24.94755 12.71769,17.50441"
+           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 688.35431,24.94755 17.50441,17.50441"
+           id="path5393"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 558.57141,24.94755 0,17.71654"
+           id="path5424"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
            id="path5426"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
+           d="m 532.26925,24.94755 -2.77243,17.50441"
+           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <path
-           sodipodi:nodetypes="cc"
-           inkscape:connector-curvature="0"
-           id="path5428"
+           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="m 506.03478,24.94755 -5.75645,17.50441"
-           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 479.95037,24.94755 -8.91894,17.50441"
-           id="path5430"
+           id="path5428"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="cc" />
         <path
            sodipodi:nodetypes="cc"
            inkscape:connector-curvature="0"
-           id="path5432"
-           d="M 456.22494,24.94755 443.50725,42.45196"
+           id="path5430"
+           d="m 479.95037,24.94755 -8.91894,17.50441"
            style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <path
            style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="M 428.78851,24.94755 411.2841,42.45196"
+           d="M 456.22494,24.94755 443.50725,42.45196"
+           id="path5432"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cc" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
            id="path5434"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
+           d="M 428.78851,24.94755 411.2841,42.45196"
+           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <path
-           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           d="m 413.63592,28.901694 289.87101,0"
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
            id="path5436"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
+           d="m 413.63592,28.901694 289.87101,0"
+           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
         <path
-           inkscape:connector-curvature="0"
-           id="path5438"
+           sodipodi:nodetypes="cc"
+           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            d="m 406.66131,32.928489 303.82023,0"
-           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           sodipodi:nodetypes="cc" />
+           id="path5438"
+           inkscape:connector-curvature="0" />
         <path
-           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           d="m 399.6867,36.955283 317.76945,0"
-           id="path5440"
+           sodipodi:nodetypes="cc"
            inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
+           id="path5440"
+           d="m 399.6867,36.955283 317.76945,0"
+           style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
       </g>
     </g>
     <g
-       transform="translate(276.30046,-339.568)"
+       inkscape:label="Layer 1"
        id="layer1-1"
-       inkscape:label="Layer 1">
+       transform="translate(276.30046,-339.568)">
       <rect
-         transform="matrix(0.70600487,-0.70820697,0.70600487,0.70820697,0,0)"
-         y="530.37567"
-         x="-187.93834"
-         height="4.806571"
-         width="205.65259"
+         style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999785;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="rect4145"
-         style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999785;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <rect
-         transform="matrix(-0.70600487,-0.70820697,0.70600487,-0.70820697,0,0)"
-         y="-193.08824"
-         x="-741.17816"
-         height="4.806571"
          width="205.65259"
+         height="4.806571"
+         x="-187.93834"
+         y="530.37567"
+         transform="matrix(0.70600487,-0.70820697,0.70600487,0.70820697,0,0)" />
+      <rect
+         style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999785;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="rect4145-6"
-         style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999785;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         width="205.65259"
+         height="4.806571"
+         x="-741.17816"
+         y="-193.08824"
+         transform="matrix(-0.70600487,-0.70820697,0.70600487,-0.70820697,0,0)" />
       <path
-         inkscape:connector-curvature="0"
-         id="path4293"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
          d="m 390.34762,366.47444 -2.21123,24.43028"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path4295"
-         d="M 388.13639,390.90472 267.37357,512.5646"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path4297"
-         d="M 390.34761,658.24993 388.1364,633.81961"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path4299"
-         d="M 388.1364,633.81961 267.37357,512.5646 245.15589,512.11904"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </g>
-    <g
-       transform="matrix(0.60738264,0,0,0.60738264,-233.47856,156.02609)"
-       id="layer1-8"
-       inkscape:label="Layer 1">
-      <path
-         sodipodi:nodetypes="cscsccccccssscscsscssccscsscccccccssccccscssccsssssccsssscsssscssccsscsc"
-         style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:1"
-         d="m 1140.846,497.3677 c -0.5695,-0.14131 -0.6949,-0.39873 -0.6949,-1.42672 0,-0.5364 -0.057,-1.01011 -0.1264,-1.05269 -0.076,-0.0465 -0.1263,-0.8882 -0.1263,-2.10442 l 0,-2.027 -0.4739,-0.68136 -0.4738,-0.68136 -0.063,-2.07545 c 0,-1.76366 -0.063,-2.51542 0,-4.47823 l 0.063,-2.02699 0.5161,-0.72329 c 0.386,-0.54102 0.7204,-0.83514 1.3267,-1.16714 0.8013,-0.43873 0.8307,-0.44434 2.5481,-0.48717 l 1.7374,-0.0433 0,-1.40665 c 0,-1.35209 0.013,-1.41842 0.3275,-1.71031 0.537,-0.49791 0.6094,-0.72153 0.3132,-0.96664 -0.2256,-0.18668 -0.2626,-0.38075 -0.2916,-1.52721 l -0.033,-1.31335 -0.4824,-0.0775 c -0.7766,-0.12473 -0.8269,-0.2419 -0.8565,-1.99369 -0.021,-1.24146 0.016,-1.64835 0.1798,-1.96153 0.1133,-0.21733 0.2784,-0.41904 0.3667,-0.44825 0.1241,-0.041 0.1648,-0.83394 0.179,-3.48729 0.018,-3.32828 0.028,-3.45929 0.331,-4.24838 0.2189,-0.57005 0.4095,-0.86185 0.6356,-0.97315 0.7294,-0.35896 15.3934,-0.51313 25.2973,-0.26597 5.0668,0.12645 7.5877,0.28483 7.8402,0.49258 0.084,0.069 0.3065,0.55555 0.4948,1.08116 l 0.3422,0.95565 -0.071,3.17907 -0.071,3.17908 -0.3506,0.59121 -0.3506,0.59122 -0.063,3.12797 c -0.061,3.025 -0.072,3.13231 -0.3295,3.25944 -0.2516,0.1242 -0.2551,0.14859 -0.063,0.44194 0.1118,0.17076 0.3141,0.4019 0.4497,0.51364 0.1691,0.13936 0.2794,0.45407 0.3512,1.00208 0.2008,1.53352 0.2529,1.80207 0.3796,1.95758 0.092,0.11306 0.6709,0.15657 2.0824,0.15657 1.7634,0 1.9862,-0.0245 2.276,-0.25052 0.1767,-0.13778 0.3901,-0.25052 0.4742,-0.25052 0.4124,0 0.5686,-0.47737 0.8219,-2.51194 0.2405,-1.93081 0.2902,-2.12679 0.7926,-3.12372 0.2949,-0.58501 0.6214,-1.31778 0.7256,-1.62838 0.2722,-0.81105 1.0059,-1.26976 2.4062,-1.50442 1.5811,-0.26494 5.9895,-0.24457 7.0706,0.0327 0.4517,0.11585 1.2051,0.29605 1.6742,0.40045 1.0286,0.22891 2.0864,0.74118 2.9858,1.44591 0.7327,0.57417 2.3921,2.93482 2.7401,3.89811 0.7325,2.02742 1.5159,7.27084 1.6602,11.11218 0.099,2.37593 0.027,2.60851 -0.092,4.3784 -0.1239,1.67302 -0.4487,3.01953 -0.9213,3.81886 -0.3909,0.66126 -1.8688,2.06221 -2.2847,2.16567 -0.1763,0.0439 -0.7627,-0.0807 -1.4423,-0.30641 -0.6298,-0.20919 -1.5041,-0.43599 -1.9429,-0.504 -1.0206,-0.15822 -6.396,-0.27776 -6.4793,-0.1441 -0.077,0.12351 -1.0865,0.25198 -2.8475,0.36238 -0.9641,0.0604 -1.4185,0.1449 -1.6623,0.30898 -0.25,0.16834 -0.5234,0.21616 -1.074,0.18789 -0.7089,-0.0364 -0.7475,-0.0561 -0.9617,-0.49021 l -0.2231,-0.45229 -5.0207,-0.0932 c -2.7614,-0.0513 -9.5411,-0.0735 -15.0661,-0.0495 -5.5249,0.0241 -10.1169,-0.002 -10.2044,-0.0575 -0.087,-0.0557 -0.2723,-0.0657 -0.4107,-0.0222 -0.2132,0.0671 -0.2516,0.19026 -0.2516,0.8084 0,0.53127 -0.066,0.80951 -0.2414,1.02495 l -0.2415,0.29571 -6.4239,0.0185 c -3.5331,0.0101 -6.5376,-0.01 -6.6765,-0.0442 z"
-         id="path4433"
+         id="path4293"
          inkscape:connector-curvature="0" />
-      <ellipse
-         ry="2.7192338"
-         rx="2.7630923"
-         cy="475.44604"
-         cx="1193.7875"
-         id="path4523"
-         style="opacity:1;fill:url(#radialGradient4533);fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.1;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="M 388.13639,390.90472 267.37357,512.5646"
+         id="path4295"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="M 390.34761,658.24993 388.1364,633.81961"
+         id="path4297"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="M 388.1364,633.81961 267.37357,512.5646 245.15589,512.11904"
+         id="path4299"
+         inkscape:connector-curvature="0" />
     </g>
     <g
-       transform="translate(53.66924,73.355566)"
+       inkscape:label="Layer 1"
+       id="layer1-8"
+       transform="matrix(0.60738264,0,0,0.60738264,-233.47856,156.02609)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4433"
+         d="m 1140.846,497.3677 c -0.5695,-0.14131 -0.6949,-0.39873 -0.6949,-1.42672 0,-0.5364 -0.057,-1.01011 -0.1264,-1.05269 -0.076,-0.0465 -0.1263,-0.8882 -0.1263,-2.10442 l 0,-2.027 -0.4739,-0.68136 -0.4738,-0.68136 -0.063,-2.07545 c 0,-1.76366 -0.063,-2.51542 0,-4.47823 l 0.063,-2.02699 0.5161,-0.72329 c 0.386,-0.54102 0.7204,-0.83514 1.3267,-1.16714 0.8013,-0.43873 0.8307,-0.44434 2.5481,-0.48717 l 1.7374,-0.0433 0,-1.40665 c 0,-1.35209 0.013,-1.41842 0.3275,-1.71031 0.537,-0.49791 0.6094,-0.72153 0.3132,-0.96664 -0.2256,-0.18668 -0.2626,-0.38075 -0.2916,-1.52721 l -0.033,-1.31335 -0.4824,-0.0775 c -0.7766,-0.12473 -0.8269,-0.2419 -0.8565,-1.99369 -0.021,-1.24146 0.016,-1.64835 0.1798,-1.96153 0.1133,-0.21733 0.2784,-0.41904 0.3667,-0.44825 0.1241,-0.041 0.1648,-0.83394 0.179,-3.48729 0.018,-3.32828 0.028,-3.45929 0.331,-4.24838 0.2189,-0.57005 0.4095,-0.86185 0.6356,-0.97315 0.7294,-0.35896 15.3934,-0.51313 25.2973,-0.26597 5.0668,0.12645 7.5877,0.28483 7.8402,0.49258 0.084,0.069 0.3065,0.55555 0.4948,1.08116 l 0.3422,0.95565 -0.071,3.17907 -0.071,3.17908 -0.3506,0.59121 -0.3506,0.59122 -0.063,3.12797 c -0.061,3.025 -0.072,3.13231 -0.3295,3.25944 -0.2516,0.1242 -0.2551,0.14859 -0.063,0.44194 0.1118,0.17076 0.3141,0.4019 0.4497,0.51364 0.1691,0.13936 0.2794,0.45407 0.3512,1.00208 0.2008,1.53352 0.2529,1.80207 0.3796,1.95758 0.092,0.11306 0.6709,0.15657 2.0824,0.15657 1.7634,0 1.9862,-0.0245 2.276,-0.25052 0.1767,-0.13778 0.3901,-0.25052 0.4742,-0.25052 0.4124,0 0.5686,-0.47737 0.8219,-2.51194 0.2405,-1.93081 0.2902,-2.12679 0.7926,-3.12372 0.2949,-0.58501 0.6214,-1.31778 0.7256,-1.62838 0.2722,-0.81105 1.0059,-1.26976 2.4062,-1.50442 1.5811,-0.26494 5.9895,-0.24457 7.0706,0.0327 0.4517,0.11585 1.2051,0.29605 1.6742,0.40045 1.0286,0.22891 2.0864,0.74118 2.9858,1.44591 0.7327,0.57417 2.3921,2.93482 2.7401,3.89811 0.7325,2.02742 1.5159,7.27084 1.6602,11.11218 0.099,2.37593 0.027,2.60851 -0.092,4.3784 -0.1239,1.67302 -0.4487,3.01953 -0.9213,3.81886 -0.3909,0.66126 -1.8688,2.06221 -2.2847,2.16567 -0.1763,0.0439 -0.7627,-0.0807 -1.4423,-0.30641 -0.6298,-0.20919 -1.5041,-0.43599 -1.9429,-0.504 -1.0206,-0.15822 -6.396,-0.27776 -6.4793,-0.1441 -0.077,0.12351 -1.0865,0.25198 -2.8475,0.36238 -0.9641,0.0604 -1.4185,0.1449 -1.6623,0.30898 -0.25,0.16834 -0.5234,0.21616 -1.074,0.18789 -0.7089,-0.0364 -0.7475,-0.0561 -0.9617,-0.49021 l -0.2231,-0.45229 -5.0207,-0.0932 c -2.7614,-0.0513 -9.5411,-0.0735 -15.0661,-0.0495 -5.5249,0.0241 -10.1169,-0.002 -10.2044,-0.0575 -0.087,-0.0557 -0.2723,-0.0657 -0.4107,-0.0222 -0.2132,0.0671 -0.2516,0.19026 -0.2516,0.8084 0,0.53127 -0.066,0.80951 -0.2414,1.02495 l -0.2415,0.29571 -6.4239,0.0185 c -3.5331,0.0101 -6.5376,-0.01 -6.6765,-0.0442 z"
+         style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:1"
+         sodipodi:nodetypes="cscsccccccssscscsscssccscsscccccccssccccscssccsssssccsssscsssscssccsscsc" />
+      <ellipse
+         style="opacity:1;fill:url(#radialGradient4533);fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.1;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path4523"
+         cx="1193.7875"
+         cy="475.44604"
+         rx="2.7630923"
+         ry="2.7192338" />
+    </g>
+    <g
+       inkscape:label="Layer 1"
        id="layer1-82"
-       inkscape:label="Layer 1">
+       transform="translate(53.66924,73.355566)">
       <g
          id="g4354">
         <rect
-           style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999785;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="rect4145-1"
-           width="205.65259"
-           height="4.806571"
-           x="-539.9436"
+           transform="matrix(-0.00155712,-0.99999879,0.99999879,0.00155712,0,0)"
            y="312.93979"
-           transform="matrix(-0.00155712,-0.99999879,0.99999879,0.00155712,0,0)" />
+           x="-539.9436"
+           height="4.806571"
+           width="205.65259"
+           id="rect4145-1"
+           style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999785;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 318.26651,334.7854 15.71124,18.83839"
-           id="path4293-4"
-           inkscape:connector-curvature="0" />
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 333.97775,353.62379 0.63432,171.41874"
-           id="path4295-3"
-           inkscape:connector-curvature="0" />
-        <path
-           style="fill:none;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           d="m 325.33378,533.0687 c -3.49369,3.34908 -5.68169,5.29006 -5.82257,5.16522 -0.41016,-0.36349 -0.58694,-201.31881 -0.1768,-201.0064 0.21432,0.16327 3.44294,3.96654 7.1747,8.45175 l 6.78502,8.15492 0.29874,85.43535 0.29874,85.43535 -1.48048,1.49929 c -0.81449,0.82439 -3.99907,3.91365 -7.07736,6.86451 l 10e-6,1e-5 z"
-           id="path4170"
-           inkscape:connector-curvature="0" />
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 318.58674,540.43774 15.30487,-15.73285"
-           id="path4269"
-           inkscape:connector-curvature="0" />
-        <path
-           style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           d="M 6.2363462,168.35867 C 6.1223654,148.57522 6.0714509,103.2054 6.1232029,67.536845 l 0.094094,-64.8519204 7.1082401,8.5319424 7.10824,8.531943 0.192965,76.186199 c 0.10613,41.902411 0.277965,80.302801 0.381856,85.334201 0.154977,7.50554 0.118031,9.1042 -0.205777,8.90408 -0.276449,-0.17086 -2.486127,1.91264 -7.376952,6.95568 l -6.9822854,7.1996 -0.2072379,-35.9699 z"
-           id="path4352"
            inkscape:connector-curvature="0"
-           transform="translate(312.95916,334.27714)" />
+           id="path4293-4"
+           d="m 318.26651,334.7854 15.71124,18.83839"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4295-3"
+           d="m 333.97775,353.62379 0.63432,171.41874"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4170"
+           d="m 325.33378,533.0687 c -3.49369,3.34908 -5.68169,5.29006 -5.82257,5.16522 -0.41016,-0.36349 -0.58694,-201.31881 -0.1768,-201.0064 0.21432,0.16327 3.44294,3.96654 7.1747,8.45175 l 6.78502,8.15492 0.29874,85.43535 0.29874,85.43535 -1.48048,1.49929 c -0.81449,0.82439 -3.99907,3.91365 -7.07736,6.86451 l 10e-6,1e-5 z"
+           style="fill:none;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4269"
+           d="m 318.58674,540.43774 15.30487,-15.73285"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+        <path
+           transform="translate(312.95916,334.27714)"
+           inkscape:connector-curvature="0"
+           id="path4352"
+           d="M 6.2363462,168.35867 C 6.1223654,148.57522 6.0714509,103.2054 6.1232029,67.536845 l 0.094094,-64.8519204 7.1082401,8.5319424 7.10824,8.531943 0.192965,76.186199 c 0.10613,41.902411 0.277965,80.302801 0.381856,85.334201 0.154977,7.50554 0.118031,9.1042 -0.205777,8.90408 -0.276449,-0.17086 -2.486127,1.91264 -7.376952,6.95568 l -6.9822854,7.1996 -0.2072379,-35.9699 z"
+           style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
       </g>
     </g>
     <g
-       transform="matrix(-1,0,0,-1,973.19788,823.29586)"
+       inkscape:label="Layer 1"
        id="layer1-18"
-       inkscape:label="Layer 1">
+       transform="matrix(-1,0,0,-1,973.19788,823.29586)">
       <rect
-         transform="matrix(0.70600487,-0.70820697,0.70600487,0.70820697,0,0)"
-         y="530.37567"
-         x="-187.93834"
-         height="4.806571"
-         width="205.65259"
+         style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999785;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="rect4145-8"
-         style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999785;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <rect
-         transform="matrix(-0.70600487,-0.70820697,0.70600487,-0.70820697,0,0)"
-         y="-193.08824"
-         x="-741.17816"
-         height="4.806571"
          width="205.65259"
+         height="4.806571"
+         x="-187.93834"
+         y="530.37567"
+         transform="matrix(0.70600487,-0.70820697,0.70600487,0.70820697,0,0)" />
+      <rect
+         style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999785;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="rect4145-6-3"
-         style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999785;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         width="205.65259"
+         height="4.806571"
+         x="-741.17816"
+         y="-193.08824"
+         transform="matrix(-0.70600487,-0.70820697,0.70600487,-0.70820697,0,0)" />
       <path
-         inkscape:connector-curvature="0"
-         id="path4293-5"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
          d="m 390.34762,366.47444 -2.21123,24.43028"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+         id="path4293-5"
+         inkscape:connector-curvature="0" />
       <path
-         inkscape:connector-curvature="0"
-         id="path4295-8"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
          d="M 388.13639,390.90472 267.37357,512.5646"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+         id="path4295-8"
+         inkscape:connector-curvature="0" />
       <path
-         inkscape:connector-curvature="0"
-         id="path4297-1"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
          d="M 390.34761,658.24993 388.1364,633.81961"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+         id="path4297-1"
+         inkscape:connector-curvature="0" />
       <path
-         inkscape:connector-curvature="0"
-         id="path4299-8"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
          d="M 388.1364,633.81961 267.37357,512.5646 245.15589,512.11904"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+         id="path4299-8"
+         inkscape:connector-curvature="0" />
       <path
-         transform="translate(0,-27.637818)"
-         inkscape:connector-curvature="0"
-         id="path4328"
+         style="fill:#a0a0a0;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 255.36376,539.38308 c -4.22157,-0.0451 -7.85809,-0.14991 -8.08115,-0.23296 -0.24904,-0.0927 27.09901,-27.74201 70.85911,-71.63959 39.19557,-39.31872 71.29059,-71.45378 71.32225,-71.41124 0.0317,0.0425 -0.39596,5.00414 -0.95026,11.02579 l -1.00783,10.94846 -10.14384,10.27228 c -5.57912,5.64975 -32.69702,32.99427 -60.26199,60.76559 l -50.11814,50.49331 -1.97128,-0.0699 c -1.08421,-0.0384 -5.4253,-0.10672 -9.64687,-0.15179 z"
-         style="fill:#a0a0a0;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-      <path
-         transform="translate(0,-27.637818)"
+         id="path4328"
          inkscape:connector-curvature="0"
-         id="path4330"
+         transform="translate(0,-27.637818)" />
+      <path
+         style="fill:#000000;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 318.02228,612.34008 -71.43847,-71.68185 1.15419,-0.10419 c 0.6348,-0.0573 5.24208,-0.008 10.23839,0.10932 l 9.08421,0.2135 60.22852,60.44685 60.22852,60.44685 1.00084,11.08263 c 0.55046,6.09545 0.98766,11.10201 0.97155,11.12569 -0.0161,0.0237 -32.17659,-32.21378 -71.46775,-71.6388 z"
-         style="fill:#000000;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-      <path
-         transform="translate(0,-27.637818)"
+         id="path4330"
          inkscape:connector-curvature="0"
-         id="path4332"
+         transform="translate(0,-27.637818)" />
+      <path
+         style="fill:#000000;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 257.40445,539.30778 c -5.08581,-0.10279 -9.33638,-0.27634 -9.44571,-0.38567 -0.10933,-0.10933 3.64096,-4.09788 8.33398,-8.86344 16.84962,-17.11007 132.7945,-133.45289 132.89564,-133.35176 0.0568,0.0569 -0.23891,3.82117 -0.65724,8.36514 -0.41833,4.54397 -0.70385,8.56653 -0.63448,8.93902 0.0694,0.3725 0.0162,0.67726 -0.11813,0.67726 -0.13433,0 -0.28486,0.73815 -0.33451,1.64034 l -0.0903,1.64033 -42.14046,42.49054 c -23.17726,23.36979 -50.33529,50.71306 -60.35117,60.76283 l -18.21071,18.2723 -9.24693,-0.18689 z"
-         style="fill:#000000;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         id="path4332"
+         inkscape:connector-curvature="0"
+         transform="translate(0,-27.637818)" />
     </g>
     <g
-       transform="matrix(0.38083767,0,0,0.38083767,-295.10912,489.49872)"
+       inkscape:label="Layer 1"
        id="layer1-05"
-       inkscape:label="Layer 1">
+       transform="matrix(0.38083767,0,0,0.38083767,-295.10912,489.49872)">
       <g
          id="g4555">
         <g
-           id="layer1-6"
+           transform="matrix(0.67806152,-0.36747761,0.3132047,0.57791835,828.0319,332.65287)"
            inkscape:label="Layer 1"
-           transform="matrix(0.67806152,-0.36747761,0.3132047,0.57791835,828.0319,332.65287)" />
+           id="layer1-6" />
         <rect
-           style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0"
-           id="rect4532"
-           width="187.82608"
-           height="4.8160534"
+           y="442.11749"
            x="836.38068"
-           y="442.11749" />
-        <rect
-           style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0"
-           id="rect4532-8"
-           width="187.82608"
            height="4.8160534"
-           x="894.98834"
+           width="187.82608"
+           id="rect4532"
+           style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0" />
+        <rect
+           transform="matrix(0.5,0.8660254,-0.8660254,0.5,0,0)"
            y="-665.9303"
-           transform="matrix(0.5,0.8660254,-0.8660254,0.5,0,0)" />
-        <rect
-           style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0"
-           id="rect4532-86"
-           width="187.82608"
+           x="894.98834"
            height="4.8160534"
-           x="125.04758"
+           width="187.82608"
+           id="rect4532-8"
+           style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0" />
+        <rect
+           transform="matrix(0.5,-0.8660254,0.8660254,0.5,0,0)"
            y="1105.6398"
-           transform="matrix(0.5,-0.8660254,0.8660254,0.5,0,0)" />
+           x="125.04758"
+           height="4.8160534"
+           width="187.82608"
+           id="rect4532-86"
+           style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0" />
       </g>
     </g>
     <g
-       transform="matrix(0.62928155,0,0,0.62928155,-123.75509,202.2209)"
+       inkscape:label="Layer 1"
        id="layer1-4"
-       inkscape:label="Layer 1">
+       transform="matrix(0.62928155,0,0,0.62928155,-123.75509,202.2209)">
       <g
-         transform="translate(-23.034941,-15.198854)"
+         id="layer1-9"
          inkscape:label="Layer 1"
-         id="layer1-9">
+         transform="translate(-23.034941,-15.198854)">
         <g
-           id="g4198"
-           transform="translate(-13.244152,8.4280934)">
+           transform="translate(-13.244152,8.4280934)"
+           id="g4198">
           <g
-             transform="matrix(0.09623773,0,0,0.09623773,911.57786,408.92991)"
-             id="g4228">
+             id="g4228"
+             transform="matrix(0.09623773,0,0,0.09623773,911.57786,408.92991)">
             <path
-               sodipodi:nodetypes="csscccccsssssssscssssscscssssscccccsssssccssssscsssscsssssccssscsssssssssscsscssssccsssscssssccsscsccssssssss"
-               inkscape:connector-curvature="0"
-               id="path4210"
+               style="fill:#9f9f9f"
                d="m 676.24065,717.21896 c -1.87333,-1.06107 -3.96732,-2.97793 -4.65331,-4.25969 -1.90985,-3.56857 -5.01201,-31.04584 -5.90579,-52.3101 l -0.80122,-19.0625 -53.40594,0 -53.40594,0 -3.39817,-4.45523 c -70.34332,-156.76288 65.07644,-171.56082 64.89778,-179.22372 -0.33704,-14.45531 -0.25327,-30.5238 4.97508,-31.49907 3.71537,-0.69304 3.77864,-3.38632 0.10125,-4.3093 -1.87424,-0.4704 -3.80213,-2.13719 -4.45346,-3.8503 -0.66262,-1.74282 -1.12665,-42.63323 -1.09685,-96.65468 0.0596,-108.00651 -1.13439,-98.48347 12.58006,-100.33833 11.44443,-1.54785 281.66729,-2.59173 303.3158,-1.17173 14.27884,0.9366 18.33798,1.61818 20.32011,3.412 2.43404,2.20277 2.47139,3.92084 2.15682,99.2117 l -0.32014,96.97012 -3.4375,1.64746 c -4.39521,2.10646 -4.40086,4.74824 -0.0125,5.84965 4.65245,1.16769 5.28368,2.54235 5.30589,11.55492 0.0158,6.39706 0.44721,7.99762 2.4439,9.06622 1.59587,0.85408 2.55731,2.89881 2.8125,5.98147 l 0.38771,4.68379 23.58802,0.34064 c 14.60965,0.21097 24.16885,-0.14143 25.11405,-0.92585 0.8393,-0.69657 2.5244,-6.75609 3.7447,-13.46563 6.4519,-35.47407 9.1941,-42.83027 19.7021,-52.85282 13.447,-12.82571 25.8431,-16.98752 54.1011,-18.1636 40.594,-1.6895 65.3872,4.13533 90.625,21.29115 13.1944,8.96908 18.9538,14.08686 26.6555,23.68611 15.908,19.82731 23.3637,42.01154 23.8051,70.83045 0.096,6.23594 0.7897,11.49597 1.6554,12.54192 0.966,1.16709 1.0828,2.44699 0.3317,3.63455 -0.6377,1.00819 -1.168,4.1905 -1.1785,7.0718 -0.01,2.8813 -0.5613,5.57382 -1.224,5.98335 -0.7219,0.44618 -1.1735,12.62502 -1.1267,30.38628 0.1113,42.21126 -2.4239,63.38449 -9.6559,80.64515 -5.2517,12.53411 -10.7718,21.0786 -17.138,26.52786 -6.2951,5.38839 -10.3047,5.54685 -18.8474,0.74489 -16.6705,-9.37075 -34.8961,-12.51005 -68.2405,-11.75419 -14.5788,0.33048 -24.9447,0.0163 -28.125,-0.85255 -9.5906,-2.61998 -15.5547,-2.4949 -17.5601,0.36831 -1.655,2.36274 -3.6396,2.67995 -22.7698,3.63943 -11.5262,0.5781 -25.1908,1.34799 -30.3658,1.71086 -8.307,0.5825 -9.8077,0.34621 -12.8125,-2.0174 -1.8719,-1.47243 -3.4035,-3.83968 -3.4035,-5.26055 0,-2.38323 -0.5084,-2.52231 -6.56247,-1.79513 -3.60938,0.43353 -21.04688,0.79313 -38.75,0.79911 -30.95304,0.01 -32.1875,0.10337 -32.1875,2.42157 0,1.3259 -0.96342,3.37414 -2.14094,4.55165 -1.3551,1.35512 -2.0108,3.65135 -1.78641,6.25594 0.50776,5.8935 -1.67758,9.2817 -5.98653,9.2817 l -3.57592,0 -0.83611,10.3125 c -2.49708,30.79871 -4.10185,38.26932 -9.05815,42.16795 -4.1874,3.29381 -7.55502,3.22811 -42.31066,-0.82541 -25.73079,-3.00098 -33.17953,-3.35024 -72.43028,-3.39628 -37.5069,-0.044 -47.2283,0.34935 -68.125,2.75632 -36.99376,4.26108 -37.68385,4.29626 -41.53107,2.11721 z M 842.77173,560.96167 c 0,-39.72222 -0.24258,-45.625 -1.875,-45.625 -1.63179,0 -1.875,5.81019 -1.875,44.79166 0,24.63543 0.375,45.16668 0.83334,45.625 0.45832,0.45834 1.30207,0.83334 1.875,0.83334 0.57291,0 1.04166,-20.53125 1.04166,-45.625 z m -61.27508,22.46979 c -0.86964,-1.04786 -1.8386,-1.64779 -2.15322,-1.33317 -0.86686,0.86688 0.89444,3.23838 2.40512,3.23838 0.82888,0 0.73404,-0.71722 -0.2519,-1.90521 z m 15.02508,-11.69174 c 0,-1.59844 -3.67548,-4.39425 -4.58334,-3.48639 -0.90786,0.90787 1.88795,4.58334 3.48639,4.58334 0.60332,0 1.09695,-0.49363 1.09695,-1.09695 z m 304.98647,-49.84055 c -0.01,-1.20312 -0.8626,-4.98656 -1.9003,-8.40765 -2.704,-8.91465 -2.2464,-9.39859 8.0694,-8.53374 9.6765,0.81124 11.6989,-0.53749 8.8337,-5.89123 -1.428,-2.6682 -2.4509,-2.73709 -8.1143,-0.54653 -2.3199,0.89731 -2.2974,0.74415 0.3125,-2.12625 1.5469,-1.70128 2.8125,-3.71928 2.8125,-4.48444 0,-2.23332 -6.1472,-6.44009 -10.6431,-7.28353 -5.2307,-0.98129 -9.9285,0.35638 -8.3531,2.3785 0.6245,0.80155 1.8045,4.26987 2.6223,7.70737 0.8179,3.4375 1.7807,7.23438 2.1397,8.4375 0.5838,1.9565 -0.4122,2.1875 -9.4315,2.1875 -11.3215,0 -11.579,0.27958 -7.501,8.14351 4.1446,7.99229 7.8383,10.60649 14.9864,10.60649 5.0579,0 6.1779,-0.3973 6.1668,-2.1875 z m -227.48647,-87.8125 c -2.46985,-1.59614 -12.13853,-1.59614 -13.125,0 -0.48428,0.78357 2.17011,1.24286 7.11373,1.23086 5.55305,-0.0135 7.33153,-0.37764 6.01127,-1.23086 z m 5.625,-7.37361 5,-0.97954 -3.75,-1.11577 c -4.99012,-1.48477 -30.26271,-1.46694 -35,0.0247 l -3.75,1.18075 5.625,0.819 c 8.08169,1.1767 26.02672,1.2166 31.875,0.0709 z m -155.625,-1.37639 c -2.29645,-1.48409 -20.92135,-1.48409 -24.375,0 -1.59645,0.68601 2.69541,1.09912 11.875,1.143 9.71406,0.0464 13.76705,-0.32416 12.5,-1.143 z m 82.8264,-0.26941 c -1.97056,-0.95073 -4.00469,-0.96345 -6.875,-0.043 -3.897,1.24967 -3.77384,1.3091 2.7986,1.35021 5.80033,0.0363 6.43754,-0.16805 4.0764,-1.30721 z"
-               style="fill:#9f9f9f" />
-            <path
-               sodipodi:nodetypes="csssscscsssssssssssscssssssscssssscscsssssccssssssscsssssscssssssscssscccscsssssssssssscssssssssssscssssssccssscsssssscscccccscccsssssscscsssssssssssscsccscssscsssssssscssssssscsscsssscsccssssssccssssssccsssscccsscsccssscccssscccscssccssccsssssccccsscsscccscsccsscsscscscccssssscsccsssssscsssssssssssssssscsscscssssscscsccccscssssssssccsssscscsssssssscsssssssssssssscsssssscsscssssssssssssscsscssscsssssccssssssscssssssssssssssssscsccsccssssscsssscssssssssss"
+               id="path4210"
                inkscape:connector-curvature="0"
-               id="path4208"
+               sodipodi:nodetypes="csscccccsssssssscssssscscssssscccccsssssccssssscsssscsssssccssscsssssssssscsscssssccsssscssssccsscsccssssssss" />
+            <path
+               style="fill:#666666"
                d="m 678.1571,716.62378 c -1.5068,-0.63395 -3.58164,-2.44852 -4.61077,-4.03237 -2.20263,-3.38989 -5.2713,-28.91274 -6.50815,-54.12974 -0.47209,-9.625 -1.36203,-17.82564 -1.97764,-18.22364 -0.61561,-0.39801 -24.60257,-0.4641 -53.30436,-0.14687 l -52.18506,0.57677 -3.64045,-4.77287 c -2.33175,-3.05708 -3.10454,-4.95153 -2.1497,-5.2698 2.56468,-0.8549 1.69275,-2.42353 -5.15253,-9.26957 -7.8667,-7.86757 -14.3379,-20.2548 -15.43924,-29.55395 -0.50162,-4.2354 -2.06845,-8.52932 -4.32907,-11.86395 -3.48259,-5.13715 -3.54509,-5.54535 -3.67113,-23.97612 -0.0705,-10.3125 -0.56562,-22.125 -1.10021,-26.25 -0.53459,-4.125 -0.48436,-8.12348 0.11163,-8.8855 0.596,-0.76203 1.15609,-6.59856 1.24465,-12.97009 0.23196,-16.68834 1.17723,-19.74357 8.04606,-26.00592 14.73009,-13.42953 42.30349,-21.66635 72.31502,-21.60224 6.82518,0.0146 13.08509,-0.53425 13.91092,-1.21963 1.07421,-0.89151 1.32029,-5.06906 0.86474,-14.68026 -0.67355,-14.21042 -0.20362,-15.6872 5.31492,-16.70212 1.40021,-0.25752 2.66731,-1.62723 2.88031,-3.11359 0.28597,-1.99541 -0.56685,-2.98399 -3.4375,-3.9847 -3.3197,-1.15726 -3.83258,-1.95096 -3.9311,-6.08343 -0.77037,-32.31668 0.25649,-188.52072 1.2458,-189.51003 0.69183,-0.69182 7.04815,-1.75184 14.12518,-2.35558 15.97121,-1.36253 297.42617,-1.79098 308.21765,-0.4692 4.31769,0.52885 8.65859,1.76979 9.64645,2.75765 1.53141,1.53141 1.78524,15.8522 1.72229,97.17248 -0.0406,52.45701 -0.44402,95.96398 -0.89645,96.68216 -0.45245,0.71819 -1.94117,1.51795 -3.30828,1.77725 -4.88102,0.9258 -3.2042,8.56775 1.87998,8.56775 2.92333,0 3.73067,2.44715 3.73067,11.30825 0,6.07447 0.43493,7.58655 2.5,8.69175 1.92694,1.03126 2.5,2.61727 2.5,6.91897 l 0,5.58103 25.58103,0 c 24.25714,0 25.64994,-0.12871 26.91204,-2.487 0.732,-1.36786 2.4427,-8.82099 3.8015,-16.5625 5.5952,-31.87691 8.6476,-39.87473 18.9793,-49.72916 8.0122,-7.64199 17.7819,-12.84722 29.2927,-15.60687 13.6736,-3.27818 59.0315,-2.17562 74.8084,1.81844 30.8518,7.8104 59.721,29.10916 74.8196,55.1994 7.6247,13.17536 13.5736,38.88568 13.2739,57.36769 -0.084,5.15625 0.2331,11.80195 0.7038,14.76822 0.6044,3.8092 0.2288,7.03482 -1.2788,10.98244 -1.8778,4.91686 -2.0325,8.77915 -1.2862,32.10678 1.7013,53.18265 -6.4662,87.4416 -24.8969,104.43037 -3.11,2.8667 -6.8061,5.21219 -8.2136,5.21219 -1.4076,0 -6.3656,-1.91686 -11.0178,-4.2597 -19.5502,-9.84533 -35.8008,-12.5682 -69.7927,-11.69413 -16.7305,0.4302 -23.5231,0.15225 -27.1559,-1.11123 -7.4359,-2.58615 -15.4313,-2.20992 -17.3205,0.81506 -1.4416,2.30849 -2.915,2.5 -19.2329,2.5 -12.8804,0 -18.8884,0.50836 -22.1592,1.875 -5.0886,2.12616 -15.345,2.46812 -20.0761,0.66936 -1.8719,-0.71169 -3.9511,-3.07259 -5.075,-5.7625 -1.8383,-4.3997 -2.0659,-4.52474 -6.59783,-3.62561 -2.58161,0.51217 -20.26225,1.15352 -39.2903,1.42522 l -34.59648,0.49399 -0.78401,3.56961 c -0.6021,2.74133 -1.68971,3.75077 -4.6872,4.35025 -3.52845,0.7057 -3.69319,0.93419 -1.7159,2.38002 1.59245,1.16442 2.07751,2.94556 1.78366,6.54951 -0.3713,4.55389 -0.72358,4.98111 -4.40066,5.33696 -4.54571,0.43991 -4.09255,-1.35965 -6.63536,26.34975 -1.67568,18.25991 -3.16545,23.38256 -7.80045,26.82215 l -3.43288,2.5475 -25.94212,-2.78681 c -46.50264,-4.9955 -56.05676,-5.48131 -94.69214,-4.81504 -34.02049,0.58669 -51.00072,1.82028 -88.75,6.44751 -2.75,0.33709 -6.23284,0.0942 -7.73962,-0.53976 z m 78.7593,-107.80216 c 1.50168,-0.83328 5.54283,-1.81765 8.98033,-2.1875 l 6.25,-0.67245 0.0236,-6.25 c 0.0166,-4.4073 -0.99683,-8.23671 -3.4375,-12.98846 -1.9036,-3.70615 -3.50063,-7.9249 -3.54896,-9.375 -0.0859,-2.5777 -0.11112,-2.58075 -1.13124,-0.13654 -1.34141,3.2141 -0.26695,7.95319 2.65972,11.73108 2.34556,3.02776 3.13779,9.48439 1.30289,10.61843 -0.9992,0.61754 -9.97171,-1.03603 -10.95452,-2.01885 -0.28211,-0.28212 -0.86102,-2.25336 -1.28646,-4.38052 -0.58935,-2.94674 -0.18416,-4.3722 1.70181,-5.98701 2.14919,-1.8402 2.29862,-2.6952 1.13413,-6.48948 -0.73767,-2.40351 -2.07184,-4.6504 -2.96484,-4.99307 -1.22783,-0.47116 -1.62365,-5.02438 -1.62365,-18.67669 l 0,-18.05365 7.1875,0.37489 c 6.36711,0.33208 7.23309,0.69589 7.58694,3.18737 0.21968,1.54688 1.02718,2.8125 1.79443,2.8125 2.61545,0 7.18113,5.42749 7.18113,8.53662 0,3.04862 0.0432,3.06172 2.56691,0.77783 2.07367,-1.87664 2.41354,-3.2308 1.76878,-7.04714 -0.71249,-4.21721 -0.45692,-4.87957 2.38189,-6.17302 2.59058,-1.18035 3.77036,-1.0621 6.36501,0.63797 2.72918,1.78824 3.15341,2.92154 2.96438,7.9192 -0.1545,4.08466 0.31107,6.0031 1.55372,6.40223 0.97587,0.31345 4.16493,2.94308 7.08681,5.84363 5.0712,5.03419 5.31001,5.60768 5.25764,12.6257 -0.0301,4.04359 -0.86547,9.60198 -1.85619,12.35198 -2.40896,6.68669 -2.31191,11.54645 0.11963,5.99131 2.32403,-5.30951 5.6767,-7.07061 9.84496,-5.17141 1.75803,0.80101 3.19643,1.9286 3.19643,2.50575 0,0.57714 0.62789,1.04935 1.39531,1.04935 1.81882,0 1.06691,-55.19358 -0.77031,-56.54336 -0.6875,-0.5051 -15.92187,-0.92698 -33.85416,-0.9375 -17.9323,-0.01 -32.97429,-0.38927 -33.42666,-0.84163 -0.45236,-0.45237 -0.19599,-1.57737 0.56972,-2.5 1.09603,-1.32062 7.67566,-1.66219 30.92665,-1.60547 16.24396,0.0396 31.68567,0.4615 34.31492,0.9375 l 4.78046,0.86546 0.21954,37.12439 c 0.15223,25.74411 0.6542,37.55923 1.63746,38.54292 2.18346,2.1844 16.2828,3.11593 18.55975,1.22621 1.63275,-1.35505 1.89732,-7.90952 1.89732,-47.0026 0,-43.63397 -0.0955,-45.47906 -2.41782,-46.72195 -3.17999,-1.70187 -104.91328,-1.77156 -109.3758,-0.0749 l -3.20635,1.21903 0,45.69516 c 0,35.41506 0.35151,45.82498 1.5625,46.2722 1.28631,0.47502 14.29909,2.32031 20.70717,2.93639 0.90458,0.087 2.87333,-0.52366 4.375,-1.35693 z m 422.8408,-9.41613 c -1.3655,-1.3655 -2.3018,0.80608 -1.3214,3.06477 0.9296,2.14171 0.9969,2.13976 1.5149,-0.0439 0.2981,-1.25694 0.2111,-2.61631 -0.1935,-3.02083 z m -362.29021,1.24368 c 0.34635,-1.05476 -0.94246,-1.5625 -3.9661,-1.5625 -4.27304,0 -5.52494,1.03756 -3.58844,2.97405 1.38203,1.38204 6.98074,0.33592 7.55454,-1.41155 z m 359.05471,-6.71555 c 0,-0.97473 0.5676,-0.93204 1.8591,0.13984 2.4161,2.00519 5.9429,0.62926 5.4149,-2.11254 -0.2915,-1.51336 -1.8504,-2.2254 -5.3643,-2.4502 -5.0498,-0.32305 -7.1877,1.147 -6.0353,4.1501 0.7775,2.02604 4.1256,2.24743 4.1256,0.2728 z m -26.875,-1.09695 c 0.4249,-0.6875 0.1769,-1.25 -0.5512,-1.25 -0.7281,0 -1.3238,0.5625 -1.3238,1.25 0,0.6875 0.2481,1.25 0.5513,1.25 0.3031,0 0.8988,-0.5625 1.3237,-1.25 z m -353.62497,-8 c 5.06531,-5.06531 5.69594,-11.07465 1.69584,-16.15995 -7.17807,-9.12543 -22.44584,-3.11899 -22.44584,8.83034 0,11.45287 12.28666,15.79295 20.75,7.32961 z m 361.31477,-1.36384 c -2.3183,-2.31822 -5.8148,-2.47002 -5.8148,-0.25246 0,1.82462 6.6395,4.67029 7.288,3.12359 0.2271,-0.54173 -0.4358,-1.83374 -1.4732,-2.87113 z m 49.8102,1.86384 c -0.4249,-0.6875 -1.4424,-1.24139 -2.2612,-1.23086 -0.8946,0.0113 -0.7404,0.50278 0.3862,1.23086 2.4014,1.55191 2.8342,1.55191 1.875,0 z m -9.375,-3.75 c 0,-1.65337 0.8334,-2.5 2.4608,-2.5 1.6738,0 2.2307,-0.59964 1.7413,-1.875 -1.0205,-2.65939 -5.1233,-2.32489 -6.6581,0.54283 -1.8571,3.47008 -1.5945,6.33217 0.581,6.33217 1.0417,0 1.875,-1.11111 1.875,-2.5 z m -214.48375,-6.86335 c -0.55627,-2.21639 -0.20301,-3.3353 1.22619,-3.88374 3.76543,-1.44492 2.01833,-3.00291 -3.36741,-3.00291 -7.95025,0 -9.47538,2.27775 -4.36464,6.51851 5.27111,4.37385 7.54351,4.50243 6.50586,0.36814 z m 22.81505,1.23271 4.501,-1.88062 -4.5966,-3.11938 c -7.38967,-5.01472 -11.02169,-3.59542 -8.20442,3.20609 1.75304,4.2322 2.22192,4.33354 8.30002,1.79391 z m -6.2219,-2.67665 c -1.63012,-1.63012 -0.85186,-2.94271 1.7448,-2.94271 1.4547,0 2.3858,0.65521 2.1094,1.48438 -0.6089,1.82667 -2.6961,2.61642 -3.8542,1.45833 z m 149.0835,-4.74891 c 3.5554,-4.2839 -1.3481,-11.52585 -5.8804,-8.68475 -4.4604,2.79609 -2.8559,10.49095 2.1875,10.49095 1.2067,0 2.8685,-0.81279 3.6929,-1.8062 z m -12.663,-3.61366 c 0.5152,-2.6564 -3.4214,-4.27819 -4.8345,-1.99171 -1.217,1.96916 0.9775,5.22865 3.0547,4.53712 0.7562,-0.25175 1.5571,-1.39718 1.7798,-2.54541 z m -12.5417,-0.98519 c 0.5105,-2.69548 -5.2596,-3.8038 -8.1742,-1.57009 -1.9155,1.46805 -1.9547,1.83818 -0.314,2.9627 2.7092,1.85679 8.0383,0.98246 8.4882,-1.39261 z m -159.65599,0.11113 c 3.0613,-1.63837 3.21511,-7.22926 0.23032,-8.37198 -1.20312,-0.46061 -3.11823,-1.98494 -4.25576,-3.3874 -2.04751,-2.52434 -2.0951,-2.52565 -4.74253,-0.12976 -1.47085,1.3311 -2.50887,3.57621 -2.30673,4.98915 0.29567,2.06673 1.27838,2.56896 5.02672,2.56896 4.91321,0 6.62903,2.2161 2.24678,2.90186 -1.41243,0.22104 -2.24527,0.92416 -1.85074,1.5625 0.93271,1.50918 2.65897,1.46844 5.65194,-0.13333 z m -6.95718,-8.70608 c 0.4249,-0.6875 1.30185,-1.25 1.94877,-1.25 0.64693,0 1.17623,0.5625 1.17623,1.25 0,0.6875 -0.87695,1.25 -1.94877,1.25 -1.07183,0 -1.60113,-0.5625 -1.17623,-1.25 z m 68.33907,7.93126 c 1.2573,-1.1378 2.2859,-2.68467 2.2859,-3.4375 -10e-5,-1.9012 -8.1754,-8.24376 -10.626,-8.24376 -1.1052,0 -3.8072,-1.6849 -6.0043,-3.74421 -4.9078,-4.60012 -6.4576,-4.67821 -9.2185,-0.46459 -2.11963,3.23495 -2.09342,3.34299 1.5337,6.32054 2.0296,1.66612 6.3222,4.39313 9.5392,6.06002 3.2169,1.66689 6.2033,3.6039 6.6362,4.30447 1.1437,1.85056 3.246,1.56506 5.8538,-0.79497 z m 81.6609,-11.74376 c 0,-2.08622 -0.6681,-3.6875 -1.5387,-3.6875 -1.8859,0 -3.4009,5.47549 -2.3051,8.33123 1.2011,3.12993 3.8438,-0.0628 3.8438,-4.64373 z m -9.4673,3.29879 c 1.0693,-1.2885 1.0876,-1.99618 0.068,-2.62644 -0.7677,-0.4745 -1.0939,-1.64958 -0.7249,-2.61129 0.369,-0.96171 0.1863,-1.74856 -0.4061,-1.74856 -1.3194,0 -2.5945,3.12171 -2.5945,6.35224 0,2.82845 1.6055,3.10676 3.6577,0.63405 z m -23.2848,-5.77724 c 0.3537,-1.35247 0.1332,-2.45905 -0.4899,-2.45905 -0.6231,0 -1.133,-1.125 -1.133,-2.5 0,-2.96494 -3.154,-3.35596 -4.2401,-0.52568 -0.7028,1.83139 0.096,7.34032 1.3992,9.64888 0.8093,1.43359 3.7069,-1.2695 4.4638,-4.16415 z m 127.1099,0.68666 c 1.2774,-1.53911 0.9631,-2.07321 -1.849,-3.14237 -2.2385,-0.85106 -3.1461,-1.91834 -2.6751,-3.14572 0.4355,-1.13469 -0.017,-1.85762 -1.1621,-1.85762 -2.9,0 -3.5391,3.43707 -1.2802,6.88465 2.3166,3.53564 4.718,3.97032 6.9664,1.26106 z m -43.2201,-9.57741 c -1.1649,-1.88482 -2.5736,-1.15113 -4.062,2.11551 -2.139,4.69453 -1.7992,5.07935 1.6358,1.85238 1.6976,-1.59478 2.7894,-3.38033 2.4262,-3.96789 z m -197.01331,-0.065 c 0.59004,-3.06382 -1.55055,-10.14538 -3.2366,-10.70739 -0.82356,-0.27452 -2.04942,0.95284 -2.72414,2.72748 -1.54406,4.06118 -2.99312,4.09179 -4.81118,0.10162 -2.5898,-5.68399 -5.1533,-3.03087 -4.77683,4.9438 0.13289,2.81475 0.91808,3.88948 3.29939,4.51602 5.45302,1.43473 11.82697,0.61181 12.24936,-1.5815 z m 247.34701,0.74554 c 0.7772,-2.0253 -1.4199,-4.19463 -4.2839,-4.22972 -0.8593,-0.01 -1.5625,1.38712 -1.5625,3.10587 0,2.30776 0.6641,3.125 2.5393,3.125 1.3965,0 2.8848,-0.90053 3.3071,-2.00115 z m -172.7214,-7.99884 c 0,-4.96336 -0.3477,-5.6742 -2.9566,-6.04333 -1.6262,-0.23008 -3.5405,0.16547 -4.254,0.87899 -0.8674,0.86735 -2.0625,0.88785 -3.6059,0.0619 -1.5678,-0.83909 -3.1595,-0.77999 -4.9612,0.18421 -1.459,0.78084 -4.2929,1.09165 -6.2976,0.69071 -4.1536,-0.83072 -5.5406,1.10525 -4.3086,6.01386 0.9169,3.65342 2.1431,3.95612 15.7589,3.89017 l 10.625,-0.0515 0,-5.625 z m -16.875,1.94877 c 0,-2.5492 2.4498,-3.74897 4.161,-2.03781 1.0908,1.09085 0.988,1.7309 -0.4214,2.62195 -2.6377,1.6676 -3.7396,1.49549 -3.7396,-0.58414 z m 162.2536,0.0796 c -0.2541,-1.78119 -1.1281,-2.52566 -2.6588,-2.26481 -1.2541,0.21372 -3.1251,-0.3126 -4.1578,-1.16962 -1.514,-1.25653 -2.0974,-1.21076 -3.0131,0.2364 -1.6687,2.63719 -1.4325,3.66817 1.0136,4.42405 1.2032,0.37178 3.0313,1.12278 4.0625,1.6689 2.8398,1.50388 5.1781,0.0799 4.7536,-2.89492 z m -250.37857,-0.1534 c 0,-1.79805 -0.96518,-2.61105 -3.4375,-2.89553 -2.6825,-0.30866 -3.4375,0.12604 -3.4375,1.97917 0,3.14937 1.22924,4.22452 4.32356,3.78158 1.59637,-0.22851 2.55144,-1.30105 2.55144,-2.86522 z m 219.13977,0.29815 c 0.283,-1.46931 -0.3775,-2.17315 -2.0394,-2.17315 -2.4827,0 -4.472,2.8367 -3.0127,4.296 1.4327,1.43275 4.6258,0.0911 5.0521,-2.12285 z m -73.5148,-0.22438 c 0,-0.30317 -0.5625,-0.89887 -1.25,-1.32377 -0.6875,-0.4249 -1.25,-0.17685 -1.25,0.55123 0,0.72807 0.5625,1.32377 1.25,1.32377 0.6875,0 1.25,-0.24805 1.25,-0.55123 z m -479.99997,-6.94877 c 1.71875,-1.34442 3.82812,-2.45691 4.6875,-2.4722 2.40498,-0.0427 1.85047,-2.26794 -0.77264,-3.10047 -1.28434,-0.40764 -3.34027,-1.85179 -4.56874,-3.20924 -2.96938,-3.28113 -4.86958,-3.11849 -11.32581,0.96941 -5.53925,3.50729 -6.84377,5.3125 -3.83905,5.3125 0.9247,0 2.69938,1.125 3.94374,2.5 2.85837,3.15848 7.83713,3.15848 11.875,0 z m -7.5,-1.25 c 0,-0.6875 0.84375,-1.25 1.875,-1.25 1.03125,0 1.875,0.5625 1.875,1.25 0,0.6875 -0.84375,1.25 -1.875,1.25 -1.03125,0 -1.875,-0.5625 -1.875,-1.25 z m 0,-6.25 c 0,-0.6875 0.5293,-1.25 1.17623,-1.25 0.64692,0 1.52387,0.5625 1.94877,1.25 0.4249,0.6875 -0.1044,1.25 -1.17623,1.25 -1.07182,0 -1.94877,-0.5625 -1.94877,-1.25 z m 591.01557,4.66936 c 0.4974,-2.58322 -3.1111,-4.32387 -5.0156,-2.41936 -1.9045,1.90451 -0.1638,5.51301 2.4194,5.01553 1.1973,-0.23058 2.3656,-1.39885 2.5962,-2.59617 z m -76.4094,0.25803 c 5.0422,-1.8952 13.8712,-10.93874 15.5013,-15.87809 2.2176,-6.7192 0.4391,-12.24504 -6.1163,-19.00358 -6.3429,-6.53956 -13.8652,-9.72582 -19.5768,-8.29229 -4.4444,1.11547 -13.673,9.78447 -16.2924,15.30455 -2.8387,5.98218 -1.6043,13.71092 3.2633,20.43036 5.6731,7.83144 14.5828,10.68577 23.2209,7.43905 z m -87.0186,-4.40788 c 0.904,-1.08927 4.0645,-3.64611 7.0234,-5.68187 l 5.3798,-3.70138 -2.7305,-3.69313 c -3.3495,-4.53043 -4.7251,-4.60227 -8.6049,-0.44937 -1.6667,1.78408 -4.5772,4.04853 -6.4679,5.0321 -4.017,2.08985 -4.2218,3.30018 -1.25,7.38723 2.5688,3.53264 4.3856,3.83492 6.6501,1.10642 z m -4.552,-3.1642 c -0.9533,-1.54246 7.7276,-9.72805 10.4019,-9.80837 2.8577,-0.0859 1.6148,3.03682 -2.5,6.28109 -5.9334,4.67812 -6.9188,5.11799 -7.9019,3.52728 z m -50.63752,-2.81535 c 3.09927,-5.01472 3.1966,-5.78996 0.72695,-5.78996 -1.03125,0 -1.875,0.86354 -1.875,1.91897 0,1.05544 -0.90844,3.30544 -2.01876,5 -1.11033,1.69457 -1.43745,3.08103 -0.72695,3.08103 0.7105,0 2.46268,-1.89453 3.89376,-4.21004 z m 43.64182,-10.05264 c 0.2281,-2.00072 1.261,-4.92911 2.2952,-6.50752 2.3467,-3.58142 1.5539,-4.91001 -4.029,-6.75256 -5.95018,-1.96373 -7.65512,-1.03103 -8.44023,4.61725 -0.36548,2.62927 -1.04773,6.28083 -1.51612,8.11457 -0.72152,2.82473 -0.40272,3.42326 2.08683,3.91802 6.64882,1.32131 9.16742,0.43228 9.60332,-3.38976 z m -7.65381,-1.51792 c -2.52362,-2.52363 1.48134,-8.42149 4.84271,-7.1316 2.888,1.1082 1.7697,7.19795 -1.4052,7.65243 -1.4033,0.20087 -2.95017,-0.0335 -3.43751,-0.52083 z m -12.38606,1.7806 c 1.75394,-1.75394 2.03349,-8.5 0.35224,-8.5 -0.63128,0 -2.13518,-0.3789 -3.34202,-0.84201 -1.72407,-0.66159 -2.01296,-0.36958 -1.34817,1.3628 1.41225,3.68028 -0.28061,4.50143 -4.81867,2.33738 -4.60317,-2.19508 -6.36921,-1.68292 -5.15026,1.49363 0.52482,1.36763 1.67328,1.72837 3.80173,1.19418 2.29545,-0.57613 3.39518,-0.12 4.44643,1.84428 1.56877,2.9313 3.82407,3.34439 6.05872,1.10974 z m -113.5,-12.17886 c 0,-0.64838 2.97852,-4.7265 6.61895,-9.0625 9.69814,-11.55117 33.38105,-41.8878 33.38105,-42.75948 0,-1.09697 -11.50145,-0.87552 -24.26673,0.46723 -10.84889,1.14116 -14.35641,2.79915 -11.97978,5.66281 1.9558,2.3566 0.35976,13.44531 -2.13284,14.81824 -3.67039,2.02162 -10.52925,9.88187 -12.38655,14.19497 -0.95149,2.20959 -2.8559,4.62 -4.23204,5.35649 -3.35705,1.79664 -3.18032,5.73034 0.31044,6.90989 1.8303,0.61847 -3.08068,1.45321 -14.0625,2.39025 -9.28125,0.79193 -15.46875,1.75952 -13.75,2.1502 5.45474,1.23985 42.5,1.1282 42.5,-0.1281 z m 295.94507,-1.01259 c 0.3316,-1.00699 -0.5263,-1.45344 -2.4021,-1.25 -2.1901,0.23751 -2.918,-0.30714 -2.918,-2.18355 0,-1.95099 0.7549,-2.44833 3.4375,-2.26467 4.53,0.31012 4.6114,-3.01807 0.1017,-4.14995 -2.5651,-0.64381 -3.8504,-0.20194 -5.5624,1.91226 -2.1778,2.68945 -2.0108,5.33054 0.5454,8.62518 1.5195,1.95844 6.0782,1.4962 6.7979,-0.68927 z m 7.8049,-2.88233 c 0,-2.84288 -0.5667,-3.67622 -2.5,-3.67622 -2.8246,0 -3.0331,0.9351 -1.2523,5.61884 1.5566,4.0942 3.7523,2.95746 3.7523,-1.94262 z m -180.44161,-2.42622 c 8.77291,0 10.06361,-1.30134 3.87914,-3.91085 -7.34752,-3.10025 -23.78756,-0.57909 -26.67354,4.09052 -0.67712,1.09559 1.0902,1.2588 6.97289,0.64394 4.33392,-0.45298 11.45361,-0.82361 15.82151,-0.82361 z M 884.56535,437.86761 c 3.81245,-1.44949 4.23569,-4.99581 0.70638,-5.91875 -3.49545,-0.91409 -3.12544,-2.86219 0.54362,-2.86219 4.50556,0 10.07101,-2.38538 8.71926,-3.73712 -2.4048,-2.40481 -20.15966,-4.04738 -36.76288,-3.40108 -26.39652,1.0275 -34.22069,4.78143 -13.90179,6.66986 4.89598,0.45504 8.90179,1.10643 8.90179,1.44754 0,0.3411 -0.92969,1.3 -2.06598,2.13086 -2.69661,1.97183 -1.29332,4.06625 3.69002,5.50742 5.41015,1.56458 26.18825,1.67716 30.16958,0.16346 z m -75.02086,-0.78968 c 2.53791,-0.97388 2.5081,-2.83281 -0.0915,-5.70533 -1.1378,-1.25727 -1.45567,-2.28593 -0.70637,-2.28593 0.7493,0 2.94586,-0.60489 4.88123,-1.34419 l 3.51888,-1.34417 -3.125,-1.73653 c -3.76925,-2.09452 -17.45789,-2.34342 -24.30666,-0.44197 -5.96077,1.65492 -4.35313,2.9299 5.33666,4.23236 6.26558,0.84219 6.5033,1.0008 4.0625,2.7104 -2.90022,2.0314 -3.4036,4.88849 -1.03,5.84625 2.26144,0.91251 9.15409,0.95407 11.46026,0.0691 z m -91.14776,-2.87845 c 0,-0.98267 -2.21178,-2.39887 -5,-3.20149 -4.70595,-1.35463 -4.12291,-1.49371 9.91374,-2.3648 23.09475,-1.43322 23.79046,-3.2757 2.21125,-5.8562 -8.60448,-1.02895 -15.73455,-1.01866 -27.44112,0.0396 -23.80179,2.15161 -24.18629,3.90851 -1.27356,5.81936 6.79279,0.5665 9.42256,1.17878 7.79534,1.81496 -1.35061,0.52804 -3.96932,0.99961 -5.81938,1.04792 -1.85005,0.0484 -3.71137,0.65036 -4.13627,1.33786 -1.82935,2.95995 1.23493,3.82842 12.28942,3.48306 8.85846,-0.27676 11.46058,-0.75816 11.46058,-2.12025 z m -88.125,-33.86281 c 0,-0.6875 -0.5625,-1.25 -1.25,-1.25 -0.6875,0 -1.25,0.5625 -1.25,1.25 0,0.6875 0.5625,1.25 1.25,1.25 0.6875,0 1.25,-0.5625 1.25,-1.25 z m 0,-10 c 0,-0.6875 -0.5625,-1.25 -1.25,-1.25 -0.6875,0 -1.25,0.5625 -1.25,1.25 0,0.6875 0.5625,1.25 1.25,1.25 0.6875,0 1.25,-0.5625 1.25,-1.25 z m 207.5,-7.21708 c 0,-1.07227 -0.15918,-1.71521 -0.35371,-1.42876 -0.19454,0.28647 -1.11785,1.51809 -2.0518,2.73695 -1.47836,1.92935 -1.43259,2.11424 0.35371,1.42876 1.12849,-0.43303 2.0518,-1.66466 2.0518,-2.73695 z m -89.96153,-5.08057 c -0.92451,-1.58401 -1.20266,-0.88994 -1.17123,2.92265 0.036,4.37315 0.18806,4.63359 1.21246,2.07735 0.73837,-1.84252 0.72315,-3.69039 -0.0413,-5 z m 76.21153,4.17265 c 0,-1.8515 -0.71618,-3.125 -1.75739,-3.125 -1.42627,0 -1.48515,0.58697 -0.3125,3.11525 1.80859,3.8994 2.06989,3.90062 2.06989,0.01 z m -25.09869,-3.4375 c -0.0543,-1.54687 -0.3824,-2.10937 -0.72916,-1.25 -0.34676,0.85938 -1.70861,1.5625 -3.02631,1.5625 -1.31772,0 -2.39584,0.5625 -2.39584,1.25 0,0.6875 1.40625,1.25 3.125,1.25 2.43665,0 3.10326,-0.61951 3.02631,-2.8125 z m -168.65131,-4.6875 c 0,-0.6875 -0.5625,-1.25 -1.25,-1.25 -0.6875,0 -1.25,0.5625 -1.25,1.25 0,0.6875 0.5625,1.25 1.25,1.25 0.6875,0 1.25,-0.5625 1.25,-1.25 z m 0,-8.75 c 0,-0.6875 -0.5625,-1.25 -1.25,-1.25 -0.6875,0 -1.25,0.5625 -1.25,1.25 0,0.6875 0.5625,1.25 1.25,1.25 0.6875,0 1.25,-0.5625 1.25,-1.25 z"
-               style="fill:#666666" />
-            <path
-               sodipodi:nodetypes="csssscscsssssssssssscssssssscssssscscsssssccssssssscsssssscssssssscssscccscsssssssssssscssssssssssscssssssccssscsssssscscccccscccsssssscscsssssssssssscsccscssscsssssssscssssssscsscsssscsccssssssccssssssccsssscccsscsccssscccssscccscssccssccsssssccccsscsscccscsccsscsscscscccssssscsccsssssscsssssssssssssssscsscscssssscscsccccscssssssssccsssscscsssssssscssssssccssscsssssscsscsssssscssssssscsssssssscssscsssssssssssssssssssscsccsccssssscsssscssssssssssscscs"
+               id="path4208"
                inkscape:connector-curvature="0"
-               id="path4206"
+               sodipodi:nodetypes="csssscscsssssssssssscssssssscssssscscsssssccssssssscsssssscssssssscssscccscsssssssssssscssssssssssscssssssccssscsssssscscccccscccsssssscscsssssssssssscsccscssscsssssssscssssssscsscsssscsccssssssccssssssccsssscccsscsccssscccssscccscssccssccsssssccccsscsscccscsccsscsscscscccssssscsccsssssscsssssssssssssssscsscscssssscscsccccscssssssssccsssscscsssssssscsssssssssssssscsssssscsscssssssssssssscsscssscsssssccssssssscssssssssssssssssscsccsccssssscsssscssssssssss" />
+            <path
+               style="fill:#575757"
                d="m 678.1571,716.62378 c -1.5068,-0.63395 -3.58164,-2.44852 -4.61077,-4.03237 -2.20263,-3.38989 -5.2713,-28.91274 -6.50815,-54.12974 -0.47209,-9.625 -1.36203,-17.82564 -1.97764,-18.22364 -0.61561,-0.39801 -24.60257,-0.4641 -53.30436,-0.14687 l -52.18506,0.57677 -3.64045,-4.77287 c -2.33175,-3.05708 -3.10454,-4.95153 -2.1497,-5.2698 2.56468,-0.8549 1.69275,-2.42353 -5.15253,-9.26957 -7.8667,-7.86757 -14.3379,-20.2548 -15.43924,-29.55395 -0.50162,-4.2354 -2.06845,-8.52932 -4.32907,-11.86395 -3.48259,-5.13715 -3.54509,-5.54535 -3.67113,-23.97612 -0.0705,-10.3125 -0.56562,-22.125 -1.10021,-26.25 -0.53459,-4.125 -0.48436,-8.12348 0.11163,-8.8855 0.596,-0.76203 1.15609,-6.59856 1.24465,-12.97009 0.23196,-16.68834 1.17723,-19.74357 8.04606,-26.00592 14.73009,-13.42953 42.30349,-21.66635 72.31502,-21.60224 6.82518,0.0146 13.08509,-0.53425 13.91092,-1.21963 1.07421,-0.89151 1.32029,-5.06906 0.86474,-14.68026 -0.67355,-14.21042 -0.20362,-15.6872 5.31492,-16.70212 1.40021,-0.25752 2.66731,-1.62723 2.88031,-3.11359 0.28597,-1.99541 -0.56685,-2.98399 -3.4375,-3.9847 -3.3197,-1.15726 -3.83258,-1.95096 -3.9311,-6.08343 -0.77037,-32.31668 0.25649,-188.52072 1.2458,-189.51003 0.69183,-0.69182 7.04815,-1.75184 14.12518,-2.35558 15.97121,-1.36253 297.42617,-1.79098 308.21765,-0.4692 4.31769,0.52885 8.65859,1.76979 9.64645,2.75765 1.53141,1.53141 1.78524,15.8522 1.72229,97.17248 -0.0406,52.45701 -0.44402,95.96398 -0.89645,96.68216 -0.45245,0.71819 -1.94117,1.51795 -3.30828,1.77725 -4.88102,0.9258 -3.2042,8.56775 1.87998,8.56775 2.92333,0 3.73067,2.44715 3.73067,11.30825 0,6.07447 0.43493,7.58655 2.5,8.69175 1.92694,1.03126 2.5,2.61727 2.5,6.91897 l 0,5.58103 25.58103,0 c 24.25714,0 25.64994,-0.12871 26.91204,-2.487 0.732,-1.36786 2.4427,-8.82099 3.8015,-16.5625 5.5952,-31.87691 8.6476,-39.87473 18.9793,-49.72916 8.0122,-7.64199 17.7819,-12.84722 29.2927,-15.60687 13.6736,-3.27818 59.0315,-2.17562 74.8084,1.81844 30.8518,7.8104 59.721,29.10916 74.8196,55.1994 7.6247,13.17536 13.5736,38.88568 13.2739,57.36769 -0.084,5.15625 0.2331,11.80195 0.7038,14.76822 0.6044,3.8092 0.2288,7.03482 -1.2788,10.98244 -1.8778,4.91686 -2.0325,8.77915 -1.2862,32.10678 1.7013,53.18265 -6.4662,87.4416 -24.8969,104.43037 -3.11,2.8667 -6.8061,5.21219 -8.2136,5.21219 -1.4076,0 -6.3656,-1.91686 -11.0178,-4.2597 -19.5502,-9.84533 -35.8008,-12.5682 -69.7927,-11.69413 -16.7305,0.4302 -23.5231,0.15225 -27.1559,-1.11123 -7.4359,-2.58615 -15.4313,-2.20992 -17.3205,0.81506 -1.4416,2.30849 -2.915,2.5 -19.2329,2.5 -12.8804,0 -18.8884,0.50836 -22.1592,1.875 -5.0886,2.12616 -15.345,2.46812 -20.0761,0.66936 -1.8719,-0.71169 -3.9511,-3.07259 -5.075,-5.7625 -1.8383,-4.3997 -2.0659,-4.52474 -6.59783,-3.62561 -2.58161,0.51217 -20.26225,1.15352 -39.2903,1.42522 l -34.59648,0.49399 -0.78401,3.56961 c -0.6021,2.74133 -1.68971,3.75077 -4.6872,4.35025 -3.52845,0.7057 -3.69319,0.93419 -1.7159,2.38002 1.59245,1.16442 2.07751,2.94556 1.78366,6.54951 -0.3713,4.55389 -0.72358,4.98111 -4.40066,5.33696 -4.54571,0.43991 -4.09255,-1.35965 -6.63536,26.34975 -1.67568,18.25991 -3.16545,23.38256 -7.80045,26.82215 l -3.43288,2.5475 -25.94212,-2.78681 c -46.50264,-4.9955 -56.05676,-5.48131 -94.69214,-4.81504 -34.02049,0.58669 -51.00072,1.82028 -88.75,6.44751 -2.75,0.33709 -6.23284,0.0942 -7.73962,-0.53976 z m 78.7593,-107.80216 c 1.50168,-0.83328 5.54283,-1.81765 8.98033,-2.1875 l 6.25,-0.67245 0.0236,-6.25 c 0.0166,-4.4073 -0.99683,-8.23671 -3.4375,-12.98846 -1.9036,-3.70615 -3.50063,-7.9249 -3.54896,-9.375 -0.0859,-2.5777 -0.11112,-2.58075 -1.13124,-0.13654 -1.34141,3.2141 -0.26695,7.95319 2.65972,11.73108 2.34556,3.02776 3.13779,9.48439 1.30289,10.61843 -0.9992,0.61754 -9.97171,-1.03603 -10.95452,-2.01885 -0.28211,-0.28212 -0.86102,-2.25336 -1.28646,-4.38052 -0.58935,-2.94674 -0.18416,-4.3722 1.70181,-5.98701 2.14919,-1.8402 2.29862,-2.6952 1.13413,-6.48948 -0.73767,-2.40351 -2.07184,-4.6504 -2.96484,-4.99307 -1.22783,-0.47116 -1.62365,-5.02438 -1.62365,-18.67669 l 0,-18.05365 7.1875,0.37489 c 6.36711,0.33208 7.23309,0.69589 7.58694,3.18737 0.21968,1.54688 1.02718,2.8125 1.79443,2.8125 2.61545,0 7.18113,5.42749 7.18113,8.53662 0,3.04862 0.0432,3.06172 2.56691,0.77783 2.07367,-1.87664 2.41354,-3.2308 1.76878,-7.04714 -0.71249,-4.21721 -0.45692,-4.87957 2.38189,-6.17302 2.59058,-1.18035 3.77036,-1.0621 6.36501,0.63797 2.72918,1.78824 3.15341,2.92154 2.96438,7.9192 -0.1545,4.08466 0.31107,6.0031 1.55372,6.40223 0.97587,0.31345 4.16493,2.94308 7.08681,5.84363 5.0712,5.03419 5.31001,5.60768 5.25764,12.6257 -0.0301,4.04359 -0.86547,9.60198 -1.85619,12.35198 -2.40896,6.68669 -2.31191,11.54645 0.11963,5.99131 2.32403,-5.30951 5.6767,-7.07061 9.84496,-5.17141 1.75803,0.80101 3.19643,1.9286 3.19643,2.50575 0,0.57714 0.62789,1.04935 1.39531,1.04935 1.81882,0 1.06691,-55.19358 -0.77031,-56.54336 -0.6875,-0.5051 -15.92187,-0.92698 -33.85416,-0.9375 -17.9323,-0.01 -32.97429,-0.38927 -33.42666,-0.84163 -0.45236,-0.45237 -0.19599,-1.57737 0.56972,-2.5 1.09603,-1.32062 7.67566,-1.66219 30.92665,-1.60547 16.24396,0.0396 31.68567,0.4615 34.31492,0.9375 l 4.78046,0.86546 0.21954,37.12439 c 0.15223,25.74411 0.6542,37.55923 1.63746,38.54292 2.18346,2.1844 16.2828,3.11593 18.55975,1.22621 1.63275,-1.35505 1.89732,-7.90952 1.89732,-47.0026 0,-43.63397 -0.0955,-45.47906 -2.41782,-46.72195 -3.17999,-1.70187 -104.91328,-1.77156 -109.3758,-0.0749 l -3.20635,1.21903 0,45.69516 c 0,35.41506 0.35151,45.82498 1.5625,46.2722 1.28631,0.47502 14.29909,2.32031 20.70717,2.93639 0.90458,0.087 2.87333,-0.52366 4.375,-1.35693 z m 422.8408,-9.41613 c -1.3655,-1.3655 -2.3018,0.80608 -1.3214,3.06477 0.9296,2.14171 0.9969,2.13976 1.5149,-0.0439 0.2981,-1.25694 0.2111,-2.61631 -0.1935,-3.02083 z m -362.29021,1.24368 c 0.34635,-1.05476 -0.94246,-1.5625 -3.9661,-1.5625 -4.27304,0 -5.52494,1.03756 -3.58844,2.97405 1.38203,1.38204 6.98074,0.33592 7.55454,-1.41155 z m 359.05471,-6.71555 c 0,-0.97473 0.5676,-0.93204 1.8591,0.13984 2.4161,2.00519 5.9429,0.62926 5.4149,-2.11254 -0.2915,-1.51336 -1.8504,-2.2254 -5.3643,-2.4502 -5.0498,-0.32305 -7.1877,1.147 -6.0353,4.1501 0.7775,2.02604 4.1256,2.24743 4.1256,0.2728 z m -26.875,-1.09695 c 0.4249,-0.6875 0.1769,-1.25 -0.5512,-1.25 -0.7281,0 -1.3238,0.5625 -1.3238,1.25 0,0.6875 0.2481,1.25 0.5513,1.25 0.3031,0 0.8988,-0.5625 1.3237,-1.25 z m -353.62497,-8 c 5.06531,-5.06531 5.69594,-11.07465 1.69584,-16.15995 -7.17807,-9.12543 -22.44584,-3.11899 -22.44584,8.83034 0,11.45287 12.28666,15.79295 20.75,7.32961 z m 361.31477,-1.36384 c -2.3183,-2.31822 -5.8148,-2.47002 -5.8148,-0.25246 0,1.82462 6.6395,4.67029 7.288,3.12359 0.2271,-0.54173 -0.4358,-1.83374 -1.4732,-2.87113 z m 49.8102,1.86384 c -0.4249,-0.6875 -1.4424,-1.24139 -2.2612,-1.23086 -0.8946,0.0113 -0.7404,0.50278 0.3862,1.23086 2.4014,1.55191 2.8342,1.55191 1.875,0 z m -9.375,-3.75 c 0,-1.65337 0.8334,-2.5 2.4608,-2.5 1.6738,0 2.2307,-0.59964 1.7413,-1.875 -1.0205,-2.65939 -5.1233,-2.32489 -6.6581,0.54283 -1.8571,3.47008 -1.5945,6.33217 0.581,6.33217 1.0417,0 1.875,-1.11111 1.875,-2.5 z m -214.48375,-6.86335 c -0.55627,-2.21639 -0.20301,-3.3353 1.22619,-3.88374 3.76543,-1.44492 2.01833,-3.00291 -3.36741,-3.00291 -7.95025,0 -9.47538,2.27775 -4.36464,6.51851 5.27111,4.37385 7.54351,4.50243 6.50586,0.36814 z m 22.81505,1.23271 4.501,-1.88062 -4.5966,-3.11938 c -7.38967,-5.01472 -11.02169,-3.59542 -8.20442,3.20609 1.75304,4.2322 2.22192,4.33354 8.30002,1.79391 z m -6.2219,-2.67665 c -1.63012,-1.63012 -0.85186,-2.94271 1.7448,-2.94271 1.4547,0 2.3858,0.65521 2.1094,1.48438 -0.6089,1.82667 -2.6961,2.61642 -3.8542,1.45833 z m 149.0835,-4.74891 c 3.5554,-4.2839 -1.3481,-11.52585 -5.8804,-8.68475 -4.4604,2.79609 -2.8559,10.49095 2.1875,10.49095 1.2067,0 2.8685,-0.81279 3.6929,-1.8062 z m -12.663,-3.61366 c 0.5152,-2.6564 -3.4214,-4.27819 -4.8345,-1.99171 -1.217,1.96916 0.9775,5.22865 3.0547,4.53712 0.7562,-0.25175 1.5571,-1.39718 1.7798,-2.54541 z m -12.5417,-0.98519 c 0.5105,-2.69548 -5.2596,-3.8038 -8.1742,-1.57009 -1.9155,1.46805 -1.9547,1.83818 -0.314,2.9627 2.7092,1.85679 8.0383,0.98246 8.4882,-1.39261 z m -159.65599,0.11113 c 3.0613,-1.63837 3.21511,-7.22926 0.23032,-8.37198 -1.20312,-0.46061 -3.11823,-1.98494 -4.25576,-3.3874 -2.04751,-2.52434 -2.0951,-2.52565 -4.74253,-0.12976 -1.47085,1.3311 -2.50887,3.57621 -2.30673,4.98915 0.29567,2.06673 1.27838,2.56896 5.02672,2.56896 4.91321,0 6.62903,2.2161 2.24678,2.90186 -1.41243,0.22104 -2.24527,0.92416 -1.85074,1.5625 0.93271,1.50918 2.65897,1.46844 5.65194,-0.13333 z m -6.95718,-8.70608 c 0.4249,-0.6875 1.30185,-1.25 1.94877,-1.25 0.64693,0 1.17623,0.5625 1.17623,1.25 0,0.6875 -0.87695,1.25 -1.94877,1.25 -1.07183,0 -1.60113,-0.5625 -1.17623,-1.25 z m 68.33907,7.93126 c 1.2573,-1.1378 2.2859,-2.68467 2.2859,-3.4375 -10e-5,-1.9012 -8.1754,-8.24376 -10.626,-8.24376 -1.1052,0 -3.8072,-1.6849 -6.0043,-3.74421 -4.9078,-4.60012 -6.4576,-4.67821 -9.2185,-0.46459 -2.11963,3.23495 -2.09342,3.34299 1.5337,6.32054 2.0296,1.66612 6.3222,4.39313 9.5392,6.06002 3.2169,1.66689 6.2033,3.6039 6.6362,4.30447 1.1437,1.85056 3.246,1.56506 5.8538,-0.79497 z m 81.6609,-11.74376 c 0,-2.08622 -0.6681,-3.6875 -1.5387,-3.6875 -1.8859,0 -3.4009,5.47549 -2.3051,8.33123 1.2011,3.12993 3.8438,-0.0628 3.8438,-4.64373 z m -9.4673,3.29879 c 1.0693,-1.2885 1.0876,-1.99618 0.068,-2.62644 -0.7677,-0.4745 -1.0939,-1.64958 -0.7249,-2.61129 0.369,-0.96171 0.1863,-1.74856 -0.4061,-1.74856 -1.3194,0 -2.5945,3.12171 -2.5945,6.35224 0,2.82845 1.6055,3.10676 3.6577,0.63405 z m -23.2848,-5.77724 c 0.3537,-1.35247 0.1332,-2.45905 -0.4899,-2.45905 -0.6231,0 -1.133,-1.125 -1.133,-2.5 0,-2.96494 -3.154,-3.35596 -4.2401,-0.52568 -0.7028,1.83139 0.096,7.34032 1.3992,9.64888 0.8093,1.43359 3.7069,-1.2695 4.4638,-4.16415 z m 127.1099,0.68666 c 1.2774,-1.53911 0.9631,-2.07321 -1.849,-3.14237 -2.2385,-0.85106 -3.1461,-1.91834 -2.6751,-3.14572 0.4355,-1.13469 -0.017,-1.85762 -1.1621,-1.85762 -2.9,0 -3.5391,3.43707 -1.2802,6.88465 2.3166,3.53564 4.718,3.97032 6.9664,1.26106 z m -43.2201,-9.57741 c -1.1649,-1.88482 -2.5736,-1.15113 -4.062,2.11551 -2.139,4.69453 -1.7992,5.07935 1.6358,1.85238 1.6976,-1.59478 2.7894,-3.38033 2.4262,-3.96789 z m -197.01331,-0.065 c 0.59004,-3.06382 -1.55055,-10.14538 -3.2366,-10.70739 -0.82356,-0.27452 -2.04942,0.95284 -2.72414,2.72748 -1.54406,4.06118 -2.99312,4.09179 -4.81118,0.10162 -2.5898,-5.68399 -5.1533,-3.03087 -4.77683,4.9438 0.13289,2.81475 0.91808,3.88948 3.29939,4.51602 5.45302,1.43473 11.82697,0.61181 12.24936,-1.5815 z m 247.34701,0.74554 c 0.7772,-2.0253 -1.4199,-4.19463 -4.2839,-4.22972 -0.8593,-0.01 -1.5625,1.38712 -1.5625,3.10587 0,2.30776 0.6641,3.125 2.5393,3.125 1.3965,0 2.8848,-0.90053 3.3071,-2.00115 z m -172.7214,-7.99884 c 0,-4.96336 -0.3477,-5.6742 -2.9566,-6.04333 -1.6262,-0.23008 -3.5405,0.16547 -4.254,0.87899 -0.8674,0.86735 -2.0625,0.88785 -3.6059,0.0619 -1.5678,-0.83909 -3.1595,-0.77999 -4.9612,0.18421 -1.459,0.78084 -4.2929,1.09165 -6.2976,0.69071 -4.1536,-0.83072 -5.5406,1.10525 -4.3086,6.01386 0.9169,3.65342 2.1431,3.95612 15.7589,3.89017 l 10.625,-0.0515 0,-5.625 z m -16.875,1.94877 c 0,-2.5492 2.4498,-3.74897 4.161,-2.03781 1.0908,1.09085 0.988,1.7309 -0.4214,2.62195 -2.6377,1.6676 -3.7396,1.49549 -3.7396,-0.58414 z m 162.2536,0.0796 c -0.2541,-1.78119 -1.1281,-2.52566 -2.6588,-2.26481 -1.2541,0.21372 -3.1251,-0.3126 -4.1578,-1.16962 -1.514,-1.25653 -2.0974,-1.21076 -3.0131,0.2364 -1.6687,2.63719 -1.4325,3.66817 1.0136,4.42405 1.2032,0.37178 3.0313,1.12278 4.0625,1.6689 2.8398,1.50388 5.1781,0.0799 4.7536,-2.89492 z m -250.37857,-0.1534 c 0,-1.79805 -0.96518,-2.61105 -3.4375,-2.89553 -2.6825,-0.30866 -3.4375,0.12604 -3.4375,1.97917 0,3.14937 1.22924,4.22452 4.32356,3.78158 1.59637,-0.22851 2.55144,-1.30105 2.55144,-2.86522 z m 219.13977,0.29815 c 0.283,-1.46931 -0.3775,-2.17315 -2.0394,-2.17315 -2.4827,0 -4.472,2.8367 -3.0127,4.296 1.4327,1.43275 4.6258,0.0911 5.0521,-2.12285 z m -73.5148,-0.22438 c 0,-0.30317 -0.5625,-0.89887 -1.25,-1.32377 -0.6875,-0.4249 -1.25,-0.17685 -1.25,0.55123 0,0.72807 0.5625,1.32377 1.25,1.32377 0.6875,0 1.25,-0.24805 1.25,-0.55123 z m -479.99997,-6.94877 c 1.71875,-1.34442 3.82812,-2.45691 4.6875,-2.4722 2.40498,-0.0427 1.85047,-2.26794 -0.77264,-3.10047 -1.28434,-0.40764 -3.34027,-1.85179 -4.56874,-3.20924 -2.96938,-3.28113 -4.86958,-3.11849 -11.32581,0.96941 -5.53925,3.50729 -6.84377,5.3125 -3.83905,5.3125 0.9247,0 2.69938,1.125 3.94374,2.5 2.85837,3.15848 7.83713,3.15848 11.875,0 z m -7.5,-1.25 c 0,-0.6875 0.84375,-1.25 1.875,-1.25 1.03125,0 1.875,0.5625 1.875,1.25 0,0.6875 -0.84375,1.25 -1.875,1.25 -1.03125,0 -1.875,-0.5625 -1.875,-1.25 z m 0,-6.25 c 0,-0.6875 0.5293,-1.25 1.17623,-1.25 0.64692,0 1.52387,0.5625 1.94877,1.25 0.4249,0.6875 -0.1044,1.25 -1.17623,1.25 -1.07182,0 -1.94877,-0.5625 -1.94877,-1.25 z m 591.01557,4.66936 c 0.4974,-2.58322 -3.1111,-4.32387 -5.0156,-2.41936 -1.9045,1.90451 -0.1638,5.51301 2.4194,5.01553 1.1973,-0.23058 2.3656,-1.39885 2.5962,-2.59617 z m -76.4094,0.25803 c 5.0422,-1.8952 13.8712,-10.93874 15.5013,-15.87809 2.2176,-6.7192 0.4391,-12.24504 -6.1163,-19.00358 -6.3429,-6.53956 -13.8652,-9.72582 -19.5768,-8.29229 -4.4444,1.11547 -13.673,9.78447 -16.2924,15.30455 -2.8387,5.98218 -1.6043,13.71092 3.2633,20.43036 5.6731,7.83144 14.5828,10.68577 23.2209,7.43905 z m -87.0186,-4.40788 c 0.904,-1.08927 4.0645,-3.64611 7.0234,-5.68187 l 5.3798,-3.70138 -2.7305,-3.69313 c -3.3495,-4.53043 -4.7251,-4.60227 -8.6049,-0.44937 -1.6667,1.78408 -4.5772,4.04853 -6.4679,5.0321 -4.017,2.08985 -4.2218,3.30018 -1.25,7.38723 2.5688,3.53264 4.3856,3.83492 6.6501,1.10642 z m -4.552,-3.1642 c -0.9533,-1.54246 7.7276,-9.72805 10.4019,-9.80837 2.8577,-0.0859 1.6148,3.03682 -2.5,6.28109 -5.9334,4.67812 -6.9188,5.11799 -7.9019,3.52728 z m -50.63752,-2.81535 c 3.09927,-5.01472 3.1966,-5.78996 0.72695,-5.78996 -1.03125,0 -1.875,0.86354 -1.875,1.91897 0,1.05544 -0.90844,3.30544 -2.01876,5 -1.11033,1.69457 -1.43745,3.08103 -0.72695,3.08103 0.7105,0 2.46268,-1.89453 3.89376,-4.21004 z m 43.64182,-10.05264 c 0.2281,-2.00072 1.261,-4.92911 2.2952,-6.50752 2.3467,-3.58142 1.5539,-4.91001 -4.029,-6.75256 -5.95018,-1.96373 -7.65512,-1.03103 -8.44023,4.61725 -0.36548,2.62927 -1.04773,6.28083 -1.51612,8.11457 -0.72152,2.82473 -0.40272,3.42326 2.08683,3.91802 6.64882,1.32131 9.16742,0.43228 9.60332,-3.38976 z m -7.65381,-1.51792 c -2.52362,-2.52363 1.48134,-8.42149 4.84271,-7.1316 2.888,1.1082 1.7697,7.19795 -1.4052,7.65243 -1.4033,0.20087 -2.95017,-0.0335 -3.43751,-0.52083 z m -12.38606,1.7806 c 1.75394,-1.75394 2.03349,-8.5 0.35224,-8.5 -0.63128,0 -2.13518,-0.3789 -3.34202,-0.84201 -1.72407,-0.66159 -2.01296,-0.36958 -1.34817,1.3628 1.41225,3.68028 -0.28061,4.50143 -4.81867,2.33738 -4.60317,-2.19508 -6.36921,-1.68292 -5.15026,1.49363 0.52482,1.36763 1.67328,1.72837 3.80173,1.19418 2.29545,-0.57613 3.39518,-0.12 4.44643,1.84428 1.56877,2.9313 3.82407,3.34439 6.05872,1.10974 z m -113.5,-12.17886 c 0,-0.64838 2.97852,-4.7265 6.61895,-9.0625 9.69814,-11.55117 33.38105,-41.8878 33.38105,-42.75948 0,-1.09697 -11.50145,-0.87552 -24.26673,0.46723 -10.84889,1.14116 -14.35641,2.79915 -11.97978,5.66281 8.63673,10.22212 -27.66035,37.77588 -18.44099,41.27959 1.8303,0.61847 -3.08068,1.45321 -14.0625,2.39025 -9.28125,0.79193 -15.46875,1.75952 -13.75,2.1502 5.45474,1.23985 42.5,1.1282 42.5,-0.1281 z m 295.94507,-1.01259 c 0.3316,-1.00699 -0.5263,-1.45344 -2.4021,-1.25 -2.1901,0.23751 -2.918,-0.30714 -2.918,-2.18355 0,-1.95099 0.7549,-2.44833 3.4375,-2.26467 4.53,0.31012 4.6114,-3.01807 0.1017,-4.14995 -2.5651,-0.64381 -3.8504,-0.20194 -5.5624,1.91226 -2.1778,2.68945 -2.0108,5.33054 0.5454,8.62518 1.5195,1.95844 6.0782,1.4962 6.7979,-0.68927 z m 7.8049,-2.88233 c 0,-2.84288 -0.5667,-3.67622 -2.5,-3.67622 -2.8246,0 -3.0331,0.9351 -1.2523,5.61884 1.5566,4.0942 3.7523,2.95746 3.7523,-1.94262 z m -180.44161,-2.42622 c 8.77291,0 10.06361,-1.30134 3.87914,-3.91085 -7.34752,-3.10025 -23.78756,-0.57909 -26.67354,4.09052 -0.67712,1.09559 1.0902,1.2588 6.97289,0.64394 4.33392,-0.45298 11.45361,-0.82361 15.82151,-0.82361 z M 825.3094,437.687 c 4.44803,-0.009 22.86688,0.35762 40.93078,0.81502 28.92867,0.7325 33.20745,0.59311 35.89731,-1.16935 4.21545,-2.76208 2.76115,-5.52106 -3.84102,-7.28688 -4.02699,-1.07704 -5.09875,-1.84125 -4.16322,-2.9685 1.75502,-2.11466 0.38445,-2.69663 -10.24016,-4.3483 -10.86918,-1.68968 -40.63511,-0.83775 -47.94241,1.37215 -4.79017,1.44868 -4.85696,1.5435 -2.119,3.00882 l 2.82706,1.513 -3.25232,1.48185 c -4.00708,1.82575 -7.34817,1.85987 -13.54773,0.13837 -3.09857,-0.86041 -4.56694,-1.90571 -4.16142,-2.96246 1.53522,-4.00075 -15.32444,-6.02011 -25.85314,-3.09655 -4.27026,1.18575 -4.56406,1.50799 -2.6506,2.90715 1.89925,1.38876 1.32554,1.90901 -4.8849,4.42964 -5.82038,2.36232 -8.41146,4.3748 -6.7244,5.22278 0.95135,0.47819 36.97339,1.76707 39.10017,1.39902 1.39573,-0.24154 6.17698,-0.44663 10.625,-0.45576 z m -82.08545,-1.85322 c 2.16988,-1.28472 2.07232,-1.5594 -1.44296,-4.0625 -2.0736,-1.47654 -4.5271,-2.70999 -5.45222,-2.74099 -0.92513,-0.031 0.005,-0.78423 2.06796,-1.67382 3.3669,-1.4522 3.4946,-1.69774 1.25,-2.40339 -1.375,-0.43226 -7.73126,-1.41151 -14.12501,-2.17609 -12.14003,-1.45173 -41.11703,0.21635 -45.1911,2.60148 -1.597,0.93495 -1.48023,1.1388 0.67027,1.17019 6.01834,0.0879 3.82014,1.96437 -3.98955,3.40575 -12.45566,2.29885 -14.026,5.01547 -3.9039,6.75363 8.45816,1.45244 67.42865,0.71716 70.11651,-0.87426 z M 630.27173,400.33667 c 0,-0.6875 -0.5625,-1.25 -1.25,-1.25 -0.6875,0 -1.25,0.5625 -1.25,1.25 0,0.6875 0.5625,1.25 1.25,1.25 0.6875,0 1.25,-0.5625 1.25,-1.25 z m 0,-10 c 0,-0.6875 -0.5625,-1.25 -1.25,-1.25 -0.6875,0 -1.25,0.5625 -1.25,1.25 0,0.6875 0.5625,1.25 1.25,1.25 0.6875,0 1.25,-0.5625 1.25,-1.25 z m 207.5,-7.21708 c 0,-1.07227 -0.15918,-1.71521 -0.35371,-1.42876 -0.19454,0.28647 -1.11785,1.51809 -2.0518,2.73695 -1.47836,1.92935 -1.43259,2.11424 0.35371,1.42876 1.12849,-0.43303 2.0518,-1.66466 2.0518,-2.73695 z m -89.96153,-5.08057 c -0.92451,-1.58401 -1.20266,-0.88994 -1.17123,2.92265 0.036,4.37315 0.18806,4.63359 1.21246,2.07735 0.73837,-1.84252 0.72315,-3.69039 -0.0413,-5 z m 76.21153,4.17265 c 0,-1.8515 -0.71618,-3.125 -1.75739,-3.125 -1.42627,0 -1.48515,0.58697 -0.3125,3.11525 1.80859,3.8994 2.06989,3.90062 2.06989,0.01 z m -25.09869,-3.4375 c -0.0543,-1.54687 -0.3824,-2.10937 -0.72916,-1.25 -0.34676,0.85938 -1.70861,1.5625 -3.02631,1.5625 -1.31772,0 -2.39584,0.5625 -2.39584,1.25 0,0.6875 1.40625,1.25 3.125,1.25 2.43665,0 3.10326,-0.61951 3.02631,-2.8125 z m -168.65131,-4.6875 c 0,-0.6875 -0.5625,-1.25 -1.25,-1.25 -0.6875,0 -1.25,0.5625 -1.25,1.25 0,0.6875 0.5625,1.25 1.25,1.25 0.6875,0 1.25,-0.5625 1.25,-1.25 z m 0,-8.75 c 0,-0.6875 -0.5625,-1.25 -1.25,-1.25 -0.6875,0 -1.25,0.5625 -1.25,1.25 0,0.6875 0.5625,1.25 1.25,1.25 0.6875,0 1.25,-0.5625 1.25,-1.25 z m 158.9375,-133.125 c 0,-0.65313 -0.60469,-1.38906 -1.34375,-1.63542 -0.73906,-0.24635 -1.34375,0.48959 -1.34375,1.63542 0,1.14583 0.60469,1.88177 1.34375,1.63542 0.73906,-0.24636 1.34375,-0.98229 1.34375,-1.63542 z"
-               style="fill:#575757" />
-            <path
-               sodipodi:nodetypes="csssscssssssssssssssssssssssscsssscsscscssssscssscsssscssssscsccssssscsscscccssssssccsssccsssssssscccsssssssccssssssssssscssssssccsssssssssssscscscsssccssccsssssssscssssssssssssscssssssscscsscsssssscssccssssscssscccccccssscccccccccccccscssssscsscscssscscsccccssssssssssssscccssccccsssssssssscsssssssccssscssscsscsscccscssscsscscsscssssscsccsssssssccsscsscssssssssscsssssssssssssscscccscsscccscccccccsssccsccssssscsssccsscscssscssscsscccccscssccccsccsssscscscscsssssssssssssssssssssccscsssccsssssssssscsssccscsssscscssssssscssscsssscccccssssssccsscscsssscccccsssscssssssccsscscsscsssssscsscsscscsssscssssssscsscccccccsscsssscssscccssssscscccsssssssssssscscsscsccccscsssscsssssssscssssscssssccscccccccccsccsssssscsccsccssssssssccsccccscsssssccccc"
+               id="path4206"
                inkscape:connector-curvature="0"
-               id="path4204"
+               sodipodi:nodetypes="csssscscsssssssssssscssssssscssssscscsssssccssssssscsssssscssssssscssscccscsssssssssssscssssssssssscssssssccssscsssssscscccccscccsssssscscsssssssssssscsccscssscsssssssscssssssscsscsssscsccssssssccssssssccsssscccsscsccssscccssscccscssccssccsssssccccsscsscccscsccsscsscscscccssssscsccsssssscsssssssssssssssscsscscssssscscsccccscssssssssccsssscscsssssssscssssssccssscsssssscsscsssssscssssssscsssssssscssscsssssssssssssssssssscsccsccssssscsssscssssssssssscscs" />
+            <path
+               style="fill:#3d3d3d"
                d="m 676.18379,713.93136 c -3.00784,-2.6721 -3.5308,-4.47282 -5.21867,-17.96969 -1.03173,-8.25 -2.2396,-24 -2.68418,-35 -0.44457,-11 -1.05546,-20.42187 -1.35754,-20.9375 -0.30207,-0.51562 -24.59773,-0.9375 -53.99037,-0.9375 l -53.44115,0 -2.55082,-3.45016 c -1.98941,-2.69083 -2.25007,-3.92696 -1.18433,-5.6165 1.14432,-1.81413 0.33269,-3.07069 -4.99197,-7.72856 -7.77904,-6.80492 -14.66912,-19.39596 -16.80231,-30.70478 -0.85595,-4.53771 -2.82956,-9.87224 -4.47011,-12.08239 -2.91713,-3.92996 -2.93728,-4.19422 -2.90659,-38.125 0.017,-18.79219 0.18761,-36.69886 0.37916,-39.79261 0.19154,-3.09375 0.45143,-7.17025 0.57754,-9.0589 0.51521,-7.71618 17.677,-20.01489 35.22928,-25.24648 11.52063,-3.43381 29.74908,-5.67197 47.5,-5.83226 9.28125,-0.0838 15.96335,-0.3956 14.84911,-0.6929 -2.40092,-0.64059 -3.59911,-7.72625 -3.59911,-21.28395 0,-9.1428 0.049,-9.28265 3.69892,-10.55501 5.28663,-1.84292 6.8112,-8.5805 1.94159,-8.5805 -5.50635,0 -5.41175,1.69367 -5.47711,-98.06317 -0.0545,-83.10739 0.16636,-94.58802 1.85167,-96.27333 1.05243,-1.05243 2.29519,-1.93048 2.76172,-1.95124 40.33743,-1.79478 68.17895,-2.05349 135.84821,-1.26235 45.375,0.5305 83.40767,1.35204 84.51705,1.82564 2.17691,0.92935 2.93349,10.22121 0.93291,11.45763 -0.59627,0.36852 -0.74233,2.03188 -0.32457,3.69636 0.41775,1.66449 0.18289,4.68058 -0.52194,6.70245 -1.69116,4.85125 -0.60495,5.2396 16.64655,5.95158 15.72596,0.64902 25.11225,-0.63683 24.78466,-3.3953 -0.11837,-0.9973 -0.59396,-6.77312 -1.05673,-12.83516 -0.74308,-9.73387 -1.15614,-11.14081 -3.53467,-12.03949 -2.10181,-0.79412 -1.05381,-1.22661 4.77215,-1.96936 10.49184,-1.3376 59.2677,0.45128 63.15869,2.31638 l 3.1259,1.49837 -0.15901,74.35799 c -0.0875,40.8969 -0.56214,76.68279 -1.05485,79.52421 -0.57565,3.31974 -0.40713,5.46824 0.47152,6.01126 0.87494,0.54075 1.36734,6.62627 1.36734,16.89902 l 0,16.05395 -3.75,1.30726 c -5.83196,2.03302 -4.85536,7.98477 1.57503,9.5987 3.31538,0.83211 3.42497,1.13299 3.42497,9.40322 0,7.22458 0.39973,8.8236 2.58908,10.35708 1.92627,1.34921 2.48627,2.88735 2.1875,6.00838 l -0.40158,4.19492 -8.125,0.33137 c -11.58196,0.47235 -13.75,1.87249 -13.75,8.87986 0,6.21138 2.02663,5.86727 2.71631,-0.46123 l 0.40869,-3.75 64.63707,0.42609 c 46.9707,0.30962 65.8466,0.0269 69.0625,-1.03444 5.2506,-1.73286 5.5405,-2.8573 1.2416,-4.816 -4.174,-1.90181 -37.9203,-1.9113 -49.4095,-0.0139 -4.7849,0.79022 -9.054,1.0826 -9.4869,0.64974 -0.9364,-0.93642 3.9451,-30.18832 7.164,-42.92956 2.66,-10.52916 6.2312,-16.61431 13.882,-23.65481 10.3034,-9.48155 24.5705,-15.50214 36.7355,-15.50214 5.8677,0 4.9467,1.21032 -1.5085,1.9825 -15.2134,1.81984 -29.9407,13.15538 -37.2127,28.6425 -3.7916,8.07472 -7.4802,29.14122 -5.5168,31.50703 1.0835,1.30553 5.981,1.60109 22.1183,1.33489 l 20.7266,-0.34192 0.9309,-5.46032 c 2.2461,-13.1731 13.0452,-26.69953 26.6359,-33.36266 6.7965,-3.33209 8.6726,-3.67473 20,-3.65266 10.2719,0.02 13.5963,0.52561 18.6505,2.8364 13.8727,6.34274 23.3728,17.72308 28.1302,33.69759 2.6109,8.7668 2.7749,8.98351 7.32,9.67354 9.2866,1.40986 28.4811,7.13858 31.7862,9.48682 3.7255,2.64684 5.9881,3.08375 5.9881,1.15629 0,-0.6875 1.0918,-1.25 2.4263,-1.25 2.9888,0 4.4424,-2.09471 2.8572,-4.11725 -0.6499,-0.82926 -1.5526,-3.45893 -2.006,-5.84369 -1.2176,-6.40426 1.1794,-3.25919 4.194,5.50314 2.8383,8.24954 3.0862,9.94997 1.2884,8.83891 -0.682,-0.42152 -2.1583,-0.25257 -3.2805,0.37548 -1.7622,0.98617 -1.3966,1.8545 2.6811,6.36802 4.3837,4.85226 4.7643,5.89324 5.3199,14.55077 0.3291,5.12854 0.2352,9.32462 -0.2086,9.32462 -0.4439,0 -3.8626,-2.48874 -7.5971,-5.53054 -9.653,-7.86246 -22.2058,-14.85769 -33.7738,-18.82092 -11.4039,-3.90703 -14.6345,-4.30887 -43.7759,-5.44504 l -21.25,-0.8285 -0.3955,-3.4375 c -0.2175,-1.89062 -0.8798,-3.4375 -1.4718,-3.4375 -1.9502,0 -6.2577,6.53026 -6.2577,9.48694 0,3.60831 1.5133,3.87834 27.4718,4.90203 10.6408,0.41964 19.5803,0.99644 19.8657,1.28179 0.2853,0.28535 -0.1483,1.32264 -0.9637,2.30507 -1.2583,1.5162 -0.382,1.76094 5.796,1.61893 5.548,-0.12755 8.4583,0.51858 12.2418,2.7179 4.5157,2.62497 4.7379,2.65439 2.4634,0.32615 -1.375,-1.40749 -4.75,-3.38112 -7.5,-4.38586 -4.9503,-1.80865 -4.9618,-1.82768 -1.1578,-1.91487 4.7553,-0.10901 22.2514,5.04863 31.5187,9.29134 3.8014,1.74034 10.4784,6.29573 14.8379,10.12312 7.9026,6.93807 7.9262,6.97909 7.9262,13.72816 0,6.28202 1.4476,8.86129 2.9222,5.2068 0.3467,-0.85938 0.6749,0.99687 0.7291,4.125 0.054,3.12812 -0.4214,6.22187 -1.057,6.875 -1.2912,1.32661 -1.5861,16.48964 -0.8134,41.8125 0.781,25.59292 -2.6852,54.66795 -8.1604,68.45107 -6.6047,16.62646 -17.465,30.29893 -24.067,30.29893 -1.5727,0 -5.9927,-1.69699 -9.8221,-3.77107 -17.6592,-9.56464 -29.7282,-11.65349 -65.6715,-11.36613 -16.7465,0.13389 -28.7517,-0.27889 -30.1688,-1.0373 -1.2946,-0.69284 -5.7687,-1.54544 -9.9426,-1.89467 -6.6425,-0.5558 -7.8125,-0.31562 -9.3827,1.9262 -1.4902,2.12751 -3.034,2.53152 -9.1174,2.38601 -4.0278,-0.0964 -13.2296,0.45154 -20.4484,1.2175 -32.2069,3.41741 -33.1621,3.34875 -35.2118,-2.53091 -1.745,-5.00569 -4.4762,-6.27564 -10.49481,-4.87988 -2.7051,0.62734 -19.54336,1.16264 -37.41836,1.18958 -17.875,0.0269 -33.13805,0.46221 -33.9179,0.96731 -0.77984,0.5051 -1.62886,2.04336 -1.8867,3.41836 -0.3873,2.06533 -1.62146,2.56616 -7.09816,2.88055 -5.4445,0.31254 -6.55754,0.75935 -6.2276,2.5 0.24797,1.30821 1.83298,2.27588 4.14105,2.52814 5.03545,0.55034 6.01942,1.77624 5.03247,6.26977 -0.69001,3.14165 -1.52462,3.8674 -4.81395,4.18605 l -3.97921,0.38549 -1.00229,11.25 c -2.02318,22.70911 -4.31901,35.87255 -6.84295,39.23502 -2.28912,3.04968 -3.10041,3.26026 -12.30275,3.19337 -5.41861,-0.0394 -21.38326,-1.41778 -35.47701,-3.06309 -22.29301,-2.60251 -31.15122,-2.98788 -68.125,-2.96373 -35.68902,0.0232 -46.30613,0.46974 -66.25,2.78571 -40.78816,4.73648 -38.40631,4.66412 -42.21294,1.28241 z m 202.13156,-52.31375 c 3.08162,-1.17163 3.20753,-1.62155 3.23598,-11.5625 0.0163,-5.68889 0.56775,-17.09344 1.22547,-25.34344 1.15119,-14.43949 1.0982,-15.08174 -1.41807,-17.1875 -3.03195,-2.5373 -11.41584,-2.93056 -13.32423,-0.625 -0.83506,1.00886 -1.11804,10.64224 -0.79866,27.1875 0.43162,22.35919 0.7667,25.82414 2.62919,27.1875 2.57027,1.88148 4.2278,1.94884 8.45032,0.34344 z m 25.70638,-5.72971 c 0,-0.99068 -0.84375,-1.80123 -1.875,-1.80123 -1.88279,0 -2.5696,2.63874 -1.07565,4.13269 1.16655,1.16655 2.95065,-0.24315 2.95065,-2.33146 z m 6.80635,-17.11373 c 0.40493,-3.60937 0.97068,-13.19995 1.25723,-21.31239 l 0.52098,-14.74988 -3.31935,-1.26202 c -2.28773,-0.8698 -4.24757,-0.83909 -6.30604,0.0987 -2.46459,1.12294 -2.83817,1.95535 -2.13707,4.7619 1.7319,6.93297 3.26148,23.55059 2.58745,28.11059 -1.04017,7.03705 0.29617,10.91549 3.76101,10.91549 2.57104,0 2.98296,-0.7435 3.63579,-6.5625 z m 138.16602,-18.96375 c 1.9181,-6.85089 1.1179,-8.23435 -4.7336,-8.18425 -5.2899,0.0453 -11.9104,4.90737 -10.7609,7.90284 0.8627,2.24802 7.6896,5.74045 11.2972,5.7792 2.0758,0.0222 2.9853,-1.16903 4.1973,-5.49779 z m -76.84737,-6.14041 c 0,-3.25819 -2.45113,-3.05371 -2.91769,0.24339 -0.28635,2.02364 0.10663,2.77694 1.25,2.39583 0.91723,-0.30573 1.66769,-1.4934 1.66769,-2.63922 z m -233.50856,-0.7516 c 0.55753,-2.13201 1.76436,-2.41135 10.19547,-2.35987 5.2597,0.0321 12.93809,-0.42652 17.06309,-1.01923 l 7.5,-1.07764 0.7941,-6.25 c 0.63326,-4.98405 0.21725,-7.55069 -2.05381,-12.67154 -4.75789,-10.72818 -5.0964,-15.86126 -1.45574,-22.0736 1.72331,-2.9406 4.6297,-6.1474 6.45865,-7.12622 1.82896,-0.97883 3.86411,-2.78633 4.52256,-4.01666 0.65847,-1.23034 2.02115,-2.23698 3.02821,-2.23698 2.08687,0 2.4528,-1.96817 0.58103,-3.125 -0.6875,-0.4249 -1.25,-2.42685 -1.25,-4.44877 0,-3.03749 0.51638,-3.67623 2.97195,-3.67623 4.41371,0 6.49079,3.06644 4.71581,6.96209 -1.75447,3.85066 0.78187,8.43232 6.2267,11.24796 7.59934,3.92976 9.96594,16.81696 4.97977,27.11701 -1.73015,3.57402 -2.64423,7.88936 -2.64423,12.48337 0,7.85378 0.8195,8.57877 9.54929,8.44803 2.65414,-0.0398 7.63821,0.19488 11.07571,0.52139 3.4375,0.32651 8.35938,0.62211 10.9375,0.6569 3.83309,0.0517 4.6875,0.51894 4.6875,2.56325 0,1.66666 0.83334,2.5 2.5,2.5 1.55274,0 2.5,-0.83334 2.5,-2.19931 0,-1.20963 1.125,-2.9019 2.5,-3.7606 2.42771,-1.51613 2.5,-2.91503 2.5,-48.3817 0,-45.01067 -0.0935,-46.87045 -2.41782,-48.11442 -2.73135,-1.46177 -106.12042,-1.62503 -111.33218,-0.17581 l -3.125,0.86898 -0.32747,47.07943 c -0.3219,46.2762 -0.28398,47.10272 2.2225,48.44415 1.4025,0.75059 2.2198,1.89899 1.81621,2.55199 -1.03459,1.674 0.45577,3.68729 2.72956,3.68729 1.05504,0 2.20283,-1.08821 2.55064,-2.41826 z m 19.61361,-16.88373 c -1.33148,-3.46977 0.0904,-6.32301 3.15084,-6.32301 3.44182,0 5.86883,3.11826 4.73227,6.0801 -0.97297,2.53554 -6.93287,2.7192 -7.88311,0.24291 z m 51.15679,-0.24291 c -1.84154,-4.79896 4.79976,-8.32482 7.52943,-3.99737 0.95338,1.5114 0.86304,2.6258 -0.32931,4.0625 -2.1382,2.57636 -6.20059,2.53961 -7.20012,-0.0651 z m -54.76184,-64.2051 c 0.89047,-1.44083 46.6476,-1.47511 59.375,-0.0445 5.22315,0.5871 -4.06678,0.98136 -26.01128,1.10389 -22.48681,0.12556 -33.87262,-0.23596 -33.36372,-1.05939 z m 32.49631,71.65402 -0.94565,-3.52902 -1.03466,3.6429 c -1.17033,4.12057 -0.28343,6.62453 1.65856,4.68254 0.73669,-0.73669 0.87141,-2.74514 0.32175,-4.79642 z m 395.44616,2.94086 c 0.7555,-0.91032 1.1189,-2.97802 0.8075,-4.59488 -0.3113,-1.61686 0.022,-3.64781 0.7397,-4.51323 2.2668,-2.73123 0.8173,-9.65261 -2.3501,-11.22245 -1.5733,-0.77972 -3.5968,-2.42463 -4.4967,-3.65536 -1.1387,-1.55721 -1.9068,-1.79997 -2.5258,-0.79832 -0.4893,0.79165 -0.5142,2.04681 -0.055,2.78926 0.4589,0.74244 -0.4053,2.21816 -1.9204,3.27937 -2.7508,1.92675 -2.9817,5.32568 -0.7194,10.59203 0.6997,1.62881 0.3712,1.95787 -1.473,1.47559 -2.8353,-0.74144 -5.8992,2.50097 -4.878,5.1622 1.0846,2.82628 5.4017,2.31452 6.1992,-0.73487 0.406,-1.55278 1.2666,-2.26731 2.106,-1.74856 0.7806,0.48248 1.1313,1.62773 0.7793,2.54501 -1.1414,2.9746 5.4933,4.18804 7.7871,1.4242 z m 9.7833,-4.02043 c 0.2381,-0.7153 -0.3805,-2.4028 -1.3748,-3.75 -2.3168,-3.13928 -5.1339,-0.86656 -3.8683,3.12081 0.8593,2.70748 4.4094,3.13351 5.2431,0.62919 z m -33.5439,-2.38449 c 0.2763,-1.42502 -0.1742,-2.02606 -1.25,-1.66784 -0.925,0.30803 -1.8762,1.56259 -2.1137,2.78792 -0.2763,1.42502 0.1742,2.02606 1.25,1.66783 0.925,-0.30802 1.8762,-1.56258 2.1137,-2.78791 z m -285.43187,-0.68996 c -3.45338,-1.48396 -5.625,-1.48396 -5.625,0 0,0.6875 1.82812,1.21046 4.0625,1.16214 3.40441,-0.0736 3.65752,-0.26188 1.5625,-1.16214 z m 277.63497,-4.6875 c 0.9133,-1.20312 1.6784,-3.19736 1.7003,-4.43164 0.033,-1.88385 0.7421,-2.11237 4.4147,-1.42338 6.0316,1.13152 5.8443,-1.83278 -0.4495,-7.11677 l -4.8246,-4.05045 9.3229,-6.1468 c 5.1276,-3.38075 8.8455,-6.56173 8.2621,-7.06889 -0.5835,-0.50714 -4.4359,-1.65783 -8.5609,-2.55709 -4.125,-0.89927 -8.7458,-2.39608 -10.2685,-3.32625 -1.5227,-0.93018 -4.4379,-1.69123 -6.4783,-1.69123 -2.5794,0 -3.9453,-0.74221 -4.4829,-2.43606 -0.8553,-2.69474 -5.3548,-4.66543 -6.8511,-3.00062 -1.9927,2.21711 -3.7929,13.13757 -3.0069,18.24134 0.4506,2.92619 2.4346,8.55472 4.409,12.50784 4.1052,8.21954 7.5869,9.51003 10.1176,3.75 2.2077,-5.02505 3.9323,-5.70394 4.9434,-1.94605 0.6723,2.49846 0.1496,4.14968 -2.1959,6.93709 -1.6929,2.01197 -2.7599,4.17301 -2.371,4.8023 1.1528,1.86526 4.5356,1.30677 6.3196,-1.04334 z m 50.49,0.38627 c 0,-2.17848 -2.0496,-3.62468 -3.6954,-2.60751 -1.6637,1.02821 -0.1653,4.40874 1.9542,4.40874 0.9577,0 1.7412,-0.81055 1.7412,-1.80123 z m -410.42909,-4.44877 c 1.06102,0 3.84162,-1.9125 6.17912,-4.25 4.57185,-4.57185 5.58368,-10.20526 2.89349,-16.1096 -4.53454,-9.9522 -20.65204,-9.09412 -25.6146,1.3637 -3.50783,7.39219 -0.51393,14.54084 7.90861,18.88368 1.54687,0.7976 2.8125,2.3993 2.8125,3.55933 0,1.69238 0.38451,1.56019 1.94588,-0.66897 1.07023,-1.52798 2.81398,-2.77814 3.875,-2.77814 z m 118.38365,-13.59115 c 0.46141,-10.22513 0.50441,-19.46288 0.0955,-20.52835 -0.63717,-1.66046 -4.40202,-4.09424 -4.79148,-3.09743 -0.0735,0.18807 0.0333,9.7638 0.23722,21.27943 0.28606,16.1526 0.74205,20.9375 1.9953,20.9375 1.22224,0 1.83223,-4.60351 2.46341,-18.59115 z m -35.45453,-36.552 0.625,-49.31129 11.93701,-14.96027 c 17.5848,-22.03848 27.43799,-34.94819 27.43799,-35.94942 0,-0.48722 -1.26563,-0.89355 -2.8125,-0.90293 -5.44109,-0.033 -8.59689,-1.40973 -7.1707,-3.12819 1.52174,-1.83358 -1.49336,-5.60475 -4.48109,-5.60475 -2.16139,0 -2.30391,-1.4818 -0.33216,-3.45355 2.11436,-2.11436 -3.17261,-3.81383 -18.89741,-6.07448 -14.02637,-2.01647 -21.5143,-1.74441 -43.9496,1.59688 -12.14329,1.8085 -14.11002,1.80555 -23.19247,-0.0348 -9.35918,-1.89641 -10.7632,-1.87396 -24.6693,0.39447 -8.10992,1.32293 -15.00808,2.66812 -15.32927,2.98929 -0.32118,0.32119 1.84456,0.9844 4.81277,1.47383 8.71279,1.43663 9.33898,2.4566 2.99549,4.8792 -3.14807,1.20225 -5.72376,2.66742 -5.72376,3.25593 0,2.63644 19.88745,3.56243 52.19131,2.43009 8.18945,-0.28706 13.30949,0.0439 14.18238,0.91681 0.98809,0.98809 -0.0506,1.575 -3.75381,2.12119 -2.81594,0.41531 -7.25814,1.06694 -9.87157,1.44805 -3.34469,0.48774 -5.3393,1.66134 -6.73612,3.96344 -48.80909,9.54353 -3.93696,18.77869 -10.29695,28.9507 -3.85539,6.10731 -3.96285,7.61907 -0.78412,11.03104 2.42731,2.6054 2.42484,2.61063 -1.5625,3.31847 -5.05998,0.89825 -49.03666,2.25089 -80.86862,2.48735 l -24.375,0.18108 -0.32743,48.70242 c -0.21815,32.44881 0.0895,48.28552 0.92183,47.45318 0.77503,-0.77503 1.37382,-18.78833 1.57743,-47.45243 l 0.32817,-46.20321 23.125,0.15831 c 12.71875,0.0871 49.42187,0.2277 81.5625,0.3125 l 58.4375,0.15419 0,45.52276 c 0,25.03753 0.35055,46.4363 0.77901,47.55284 0.42845,1.11654 1.41283,1.81911 2.1875,1.5613 0.99865,-0.33238 1.59035,-14.817 2.03349,-49.78005 z m -53.75,-109.85685 c -2.23751,-0.71658 -0.64005,-1.03075 5.625,-1.10626 6.07341,-0.0733 8.17645,0.2652 6.875,1.10626 -2.19745,1.4201 -8.06573,1.4201 -12.5,0 z m 389.99997,156.7424 c 0,-1.10417 -1.4062,-3.11375 -3.125,-4.46573 -1.7187,-1.35197 -3.125,-3.4298 -3.125,-4.6174 0,-2.92748 -2.4412,-5.15927 -5.6435,-5.15927 -2.9615,0 -7.2821,7.43647 -6.1041,10.50626 0.898,2.33999 3.9979,3.49148 6.9106,2.56701 1.2709,-0.40337 3.5669,0.14637 5.102,1.22166 3.5873,2.5126 5.985,2.49156 5.985,-0.0525 z m -224.39093,-7.96656 c 0.41611,-0.6733 0.20036,-2.26345 -0.47944,-3.53368 -0.948,-1.77135 -0.6578,-2.80458 1.24539,-4.43413 1.36476,-1.16855 2.143,-2.67215 1.72942,-3.34133 -0.8247,-1.3344 -11.71927,-1.66976 -14.87717,-0.45796 -3.53801,1.35766 -2.11047,5.25992 3.33526,9.11703 5.63885,3.9939 7.82094,4.63312 9.04654,2.65007 z m 20.61563,-2.03657 c 5.6038,-2.24217 6.4986,-4.99102 2.1615,-6.64 -1.5752,-0.59886 -3.6128,-1.99118 -4.5281,-3.09404 -2.1132,-2.54632 -3.7053,-2.53093 -6.57215,0.0635 -2.79805,2.5322 -2.9017,5.24587 -0.34004,8.90313 2.32278,3.31624 2.80829,3.35639 9.27879,0.76741 z m 211.1802,-5.31157 c 4.9414,-9.23305 -3.0766,-35.24613 -11.4369,-37.10529 -3.9094,-0.86937 -5.968,0.0365 -5.968,2.62636 0,1.0835 -1.2337,1.80123 -3.0962,1.80123 -4.5475,0 -7.4608,4.90976 -5.4856,9.24496 1.3457,2.95343 1.1413,3.68116 -1.9359,6.89311 -1.8923,1.97509 -5.0812,3.91921 -7.0864,4.32026 -4.3341,0.86681 -4.889,4.24078 -0.8334,5.06701 1.5469,0.31513 4.2188,0.84225 5.9375,1.17137 1.7188,0.32911 5.5503,1.49741 8.5145,2.59621 2.9642,1.0988 6.9017,2.11059 8.75,2.24842 1.8483,0.13782 4.7668,0.96893 6.4855,1.84692 4.1137,2.10139 4.6853,2.0354 6.1549,-0.71056 z m -92.6307,-7.36319 c 0.2996,-2.10961 -0.4708,-3.14126 -3.0896,-4.1369 -4.334,-1.64779 -9.1846,0.24671 -9.1846,3.58725 0,3.4524 1.2609,4.1413 6.8297,3.73145 4.1423,-0.30485 5.1168,-0.87434 5.4445,-3.1818 z m -159.47452,0.62299 c 3.12836,-2.41093 3.32739,-7.13189 0.4231,-10.03619 -4.17191,-4.1719 -2.93319,-6.18402 7.04501,-11.44357 9.94352,-5.24127 13.20435,-7.6523 11.99078,-8.86588 -0.3849,-0.38488 -5.52173,-0.81614 -11.41519,-0.95832 -9.77105,-0.23575 -10.82881,-0.5064 -12.00256,-3.07104 -1.53202,-3.34744 -5.71463,-3.69803 -7.45648,-0.625 -1.17171,2.06716 -1.3344,2.05969 -2.95724,-0.13593 -0.9509,-1.28651 -2.79616,-2.11736 -4.1347,-1.8617 -5.56845,1.0636 -4.99724,20.35525 0.77357,26.12607 1.33873,1.33874 2.43406,2.96466 2.43406,3.61319 0,0.64851 1.02141,1.91413 2.26981,2.8125 1.2484,0.89835 2.637,2.61775 3.08578,3.82087 0.9654,2.58815 6.91175,2.96189 9.94406,0.625 z m 62.10962,-1.73108 c 1.4249,-1.81146 2.5907,-3.75802 2.5907,-4.32568 0,-1.35431 -22.6755,-17.38074 -24.5917,-17.38074 -2.0816,0 -6.65827,6.12659 -6.65827,8.91323 0,2.7505 19.11097,15.83939 23.34677,15.98999 1.5346,0.0546 3.8518,-1.3398 5.3125,-3.1968 z m 63.1121,-2.78878 c 0.3679,-0.5953 2.0098,-0.82604 3.6487,-0.51277 2.2394,0.42812 3.1493,-0.0794 3.6628,-2.04263 0.8523,-3.25945 3.4171,-3.44408 3.4171,-0.24598 0,3.7902 3.6154,4.29683 5.2387,0.7341 0.7769,-1.7052 1.8611,-3.10036 2.4093,-3.10036 0.5482,0 0.8797,-2.10937 0.7368,-4.6875 l -0.2598,-4.6875 -6.25,-0.008 c -3.4375,-0.004 -7.4989,0.50054 -9.0255,1.12128 -1.8345,0.746 -3.3699,0.63522 -4.529,-0.32673 -5.1923,-4.30921 -10.1777,7.62546 -5.5454,13.27529 1.4675,1.78993 5.5025,2.08815 6.4963,0.48014 z m -14.9358,-10.3322 3.4177,-5.16456 -3.5641,-2.91549 c -1.9603,-1.60351 -4.132,-2.93571 -4.826,-2.96044 -0.694,-0.0248 -1.9644,-1.16995 -2.8231,-2.54495 -0.8587,-1.375 -2.6407,-2.5 -3.9599,-2.5 -3.0449,0 -7.5802,5.68374 -7.5802,9.49959 0,2.83244 3.9057,6.1781 5.4313,4.65252 0.4179,-0.41796 1.1146,0.16433 1.548,1.29398 0.4335,1.12965 1.5116,2.05391 2.3957,2.05391 0.8842,0 1.9313,0.84375 2.3271,1.875 1.2546,3.26945 4.1061,2.04061 7.6335,-3.28956 z m -14.3356,-8.4379 c 0,-0.6875 0.5625,-1.59764 1.25,-2.02254 0.6875,-0.4249 1.25,-0.21004 1.25,0.47746 0,0.6875 -0.5625,1.59764 -1.25,2.02254 -0.6875,0.4249 -1.25,0.21004 -1.25,-0.47746 z m 95.857,3.38457 c 3.8935,-3.65776 3.8236,-7.28211 -0.1404,-7.28211 -2.1543,0 -3.6034,1.1425 -5,3.94205 -1.0816,2.16813 -1.9666,4.41812 -1.9666,5 0,2.0276 4.2345,1.03856 7.107,-1.65994 z m -14.9189,-1.34461 c -0.7875,-2.36524 -4.6881,-2.7015 -4.6881,-0.40415 0,1.15954 1.0688,1.96665 2.6042,1.96665 1.5275,0 2.3891,-0.64602 2.0839,-1.5625 z m -103.2737,-7.29955 c 1.3367,-5.9492 0.4501,-13.78737 -2.1082,-18.63795 -3.0058,-5.6993 -14.0194,-16.28159 -16.1101,-15.47931 -1.0703,0.41072 -1.9461,1.27233 -1.9461,1.91467 0,0.64235 -2.8125,2.91625 -6.25,5.05312 -6.649,4.13324 -7.1317,5.2086 -4.7174,10.50758 1.6809,3.68911 1.257,4.16911 -8.78285,9.94504 -6.52392,3.75323 -6.27597,5.18316 1.07405,6.19405 3.6672,0.50436 7.4678,1.90643 8.8122,3.25085 1.893,1.89298 4.2942,2.3815 12.0515,2.45186 5.3282,0.0484 10.8125,0.54695 12.1875,1.10808 3.2848,1.34049 4.3257,0.20639 5.7894,-6.30799 z m 141.8018,2.90541 c 2.4577,-1.68285 2.8664,-4.97618 0.956,-7.70356 -1.4851,-2.12031 -1.5687,-3.08334 -0.3908,-4.50257 0.8241,-0.99297 1.1178,-2.79693 0.6528,-4.00882 -0.4651,-1.21187 -0.7612,-2.42177 -0.6581,-2.68866 0.8649,-2.2388 -9.9151,-3.47234 -16.0306,-1.83436 -2.3458,0.6283 -2.8092,1.49391 -2.5,4.67042 0.2552,2.62219 1.3006,4.3033 3.192,5.1331 2.1666,0.95052 2.8125,2.26635 2.8125,5.72917 0,2.47238 0.375,4.87026 0.8334,5.32858 1.1203,1.1203 9.4514,1.02803 11.1328,-0.12325 z m -11.3412,-17.79336 c 0.4249,-0.6875 1.7238,-1.24139 2.8863,-1.23086 1.8216,0.0165 1.8546,0.18661 0.2387,1.23086 -2.4479,1.582 -4.1027,1.582 -3.125,0 z m -238.83569,15.84225 c 2.81781,-2.06042 1.69532,-6.61127 -1.9132,-7.75659 -4.71342,-1.49597 -8.15261,4.38782 -4.62608,7.91434 1.93925,1.93925 3.73056,1.89604 6.53928,-0.15775 z m 220.47739,-2.40475 c -0.3221,-3.3414 -0.9222,-4.0625 -3.3804,-4.0625 -3.4567,0 -5.8881,3.1127 -4.7494,6.0801 0.4926,1.28365 2.2248,2.0449 4.6531,2.0449 3.6114,0 3.8424,-0.26993 3.4767,-4.0625 z m -73.5167,-1.02915 c 0,-3.20331 -4.1373,-2.83991 -4.7648,0.4185 -0.2888,1.5 0.3843,2.17315 2.1732,2.17315 1.7888,0 2.5916,-0.80279 2.5916,-2.59165 z m 122.5,-0.43111 c 0,-0.28753 0.3605,-1.46203 0.801,-2.61 0.6315,-1.64578 0.1716,-1.99788 -2.1748,-1.66474 -3.8193,0.54229 -4.8995,4.7975 -1.2178,4.7975 1.4254,0 2.5916,-0.23525 2.5916,-0.52276 z m -603.40888,-4.47724 c 1.74803,-1.375 4.0137,-2.5 5.03483,-2.5 2.7918,0 3.72269,-3.70206 1.16551,-4.63506 -1.19154,-0.43474 -3.75646,-2.10094 -5.69984,-3.70268 -4.14215,-3.414 -8.58672,-3.75483 -11.00103,-0.84364 -0.94356,1.13775 -3.58262,2.84907 -5.86458,3.80294 -4.38566,1.8332 -4.7619,4.45135 -0.7474,5.20083 1.31803,0.24607 3.40271,1.5117 4.63261,2.8125 2.90722,3.07481 8.47594,3.01462 12.4799,-0.13489 z m 562.15888,0.25 c 0,-1.29372 -2.7062,-4 -4,-4 -0.55,0 -1,1.125 -1,2.5 0,1.66666 0.8334,2.5 2.5,2.5 1.375,0 2.5,-0.45 2.5,-1 z m 30.8302,-2.20902 c 1.1102,-2.89314 -1.3464,-4.80623 -3.2408,-2.52372 -1.6014,1.92957 -0.876,4.48274 1.2736,4.48274 0.6685,0 1.5538,-0.88156 1.9672,-1.95902 z m -86.7124,-0.62198 c 2.6086,-0.72438 7.1909,-3.67436 10.1829,-6.55552 10.1093,-9.73477 10.4801,-20.60499 1.0293,-30.17737 -5.1037,-5.16937 -12.9704,-9.36499 -17.6411,-9.40866 -7.8834,-0.0738 -20.4478,11.54365 -22.119,20.45174 -1.131,6.02902 1.2774,13.30826 6.3729,19.26117 6.035,7.05054 12.8358,9.02212 22.175,6.42864 z m -136.33605,-7.1065 c 4.53958,-5.97755 6.78078,-7.71724 13.31349,-10.33429 4.32026,-1.73073 8.32243,-3.98199 8.8937,-5.0028 1.02313,-1.82822 -0.019,-9.6763 -1.87627,-14.12971 -0.82639,-1.98154 -0.39778,-2.22649 3.2809,-1.875 4.02349,0.38442 4.21016,0.61934 3.79807,4.7793 -0.23836,2.40625 -1.24036,6.31401 -2.22667,8.68391 -0.98631,2.36991 -1.53756,4.97533 -1.22501,5.78983 0.68616,1.78811 12.60364,4.82953 14.45074,3.68793 0.7201,-0.44507 1.3093,-2.23788 1.3093,-3.98403 0,-1.74615 0.9088,-5.09 2.0196,-7.4308 1.1108,-2.34079 1.733,-5.35195 1.3827,-6.69148 -0.3503,-1.33952 -0.2084,-2.60309 0.3152,-2.80792 0.5236,-0.20484 1.3717,-1.72042 1.8846,-3.36795 0.8206,-2.63569 0.606,-2.9101 -1.7862,-2.28453 -1.6487,0.43115 -2.9662,0.0664 -3.3473,-0.92694 -1.6449,-4.28637 -23.81175,-5.76532 -31.71857,-2.11622 -9.44555,4.35925 -13.17755,9.50377 -7.56171,10.42376 1.93841,0.31755 0.97738,1.5572 -4.6875,6.0466 -8.02558,6.36023 -15.55214,16.64133 -14.99549,20.48347 0.35175,2.42788 8.6345,8.17904 11.84384,8.22381 0.81077,0.0113 3.93043,-3.21382 6.93258,-7.16694 z m -6.52348,0 c 0.005,-0.51562 1.12582,-2.625 2.49176,-4.6875 3.47606,-5.24868 3.21165,-7.12294 -0.9375,-6.64553 -2.03346,0.23398 -3.29945,1.06497 -3.09951,2.0345 0.38162,1.85055 -3.51623,8.98603 -4.90873,8.98603 -2.09854,0 -2.27519,-2.68038 -0.41387,-6.27976 2.46417,-4.76519 11.2775,-13.72024 13.5031,-13.72024 0.90391,0 2.62077,2.04941 3.81525,4.55425 l 2.17177,4.55426 -5.06525,4.86715 c -2.7859,2.67694 -5.06526,5.40878 -5.06526,6.07075 0,0.66198 -0.5625,1.20359 -1.25,1.20359 -0.6875,0 -1.24629,-0.42187 -1.24176,-0.9375 z m 38.41122,-17.30971 c -1.0014,-1.00139 0.30923,-4.25279 1.71431,-4.25279 0.6139,0 1.1162,1.125 1.1162,2.5 0,2.43649 -1.3258,3.2575 -2.83051,1.75279 z m -22.86805,-4.83804 c -2.05952,-1.55775 -2.11587,-1.84125 -0.37265,-1.875 1.12958,-0.0219 2.37754,0.804 2.77328,1.83525 0.89382,2.32929 0.63212,2.33361 -2.40063,0.0397 z m -121.80141,13.08525 c 0,-4.16666 -0.55555,-7.5 -1.25,-7.5 -1.37579,0 -1.75315,12.83019 -0.41666,14.16666 1.51346,1.51348 1.66666,0.90066 1.66666,-6.66666 z m -7.05886,-2.05362 c 1.84928,-0.64293 1.3454,-1.14319 -2.5,-2.48199 -3.72239,-1.29595 -16.5093,-1.68103 -56.30487,-1.69556 -28.3188,-0.01 -51.78736,0.46437 -52.15236,1.05493 -1.08837,1.76104 13.73605,2.42059 59.20773,2.63416 23.68665,0.11125 43.93665,0.71062 45,1.33189 1.06335,0.62128 2.49586,0.86684 3.18336,0.54569 0.6875,-0.32114 2.29226,-0.94625 3.56614,-1.38912 z m 3.51758,-8.31988 c -2.30914,-2.78235 -21.30183,-3.43126 -74.27122,-2.53755 -39.19974,0.66139 -48.4375,1.1361 -48.4375,2.48915 0,1.37241 10.64269,1.6719 59.41422,1.6719 52.9575,0 59.49648,0.2143 60.17094,1.97192 0.67864,1.76853 0.95364,1.77499 2.66589,0.0628 1.47393,-1.47393 1.57826,-2.30794 0.45767,-3.65817 z m 317.24935,-5.82414 c 1.1597,-0.73344 2.4167,-0.67502 3.4216,0.15899 0.8737,0.72509 2.4394,0.99181 3.4794,0.59273 2.1839,-0.83803 2.5857,-8.81396 0.6946,-13.78783 -2.1302,-5.60283 -12.5537,-9.02721 -12.5537,-4.12421 0,0.94627 -1.125,2.7386 -2.5,3.98296 -6.4691,5.85449 0.2542,17.73359 7.4581,13.17736 z m -4.9581,-6.30236 c 0,-0.6875 0.5293,-1.25 1.1763,-1.25 0.6469,0 1.5238,0.5625 1.9487,1.25 0.4249,0.6875 -0.1043,1.25 -1.1762,1.25 -1.0718,0 -1.9488,-0.5625 -1.9488,-1.25 z m -35.8186,3.07109 c -0.4071,-1.0609 -1.0083,-1.66083 -1.336,-1.33316 -0.3276,0.32766 -0.2249,1.19567 0.2282,1.92891 1.2326,1.99432 1.953,1.60689 1.1078,-0.59575 z m -4.3783,-11.84872 c -1.7575,-5.04162 -3.6746,-4.75449 -2.2158,0.33188 0.6395,2.22984 1.1627,4.23178 1.1627,4.44877 0,0.21699 0.5289,0.0676 1.1754,-0.33188 0.7252,-0.44819 0.6783,-2.15207 -0.1223,-4.44877 z m -17.3031,-6.08863 c 0,-3.03279 -12.5687,-3.57772 -17.5,-0.75874 -2.9013,1.65858 -2.387,1.78958 7.1875,1.8307 5.6719,0.0244 10.3125,-0.45803 10.3125,-1.07196 z M 634.33423,460.75882 c -0.85938,-0.34676 -2.26563,-0.34676 -3.125,0 -0.85938,0.34676 -0.15625,0.63049 1.5625,0.63049 1.71875,0 2.42187,-0.28373 1.5625,-0.63049 z m 475.70227,-1.999 c 0.2857,-1.48348 -0.3805,-2.17315 -2.0993,-2.17315 -2.8667,0 -4.4543,1.86694 -3.2477,3.81921 1.2166,1.96849 4.8674,0.84461 5.347,-1.64606 z m -17.2648,0.32685 c 0,-0.6875 1.9864,-1.25 4.4143,-1.25 2.5918,0 4.6864,-0.70942 5.0736,-1.71836 0.6266,-1.63303 5.3708,-4.10245 13.6371,-7.09835 2.9295,-1.06173 3.3398,-1.58689 1.875,-2.40026 -1.7775,-0.98704 -30.8843,-6.28303 -34.5316,-6.28303 -2.1407,0 -2.3622,10.28016 -0.3461,16.06347 1.1766,3.37509 1.9788,3.93653 5.625,3.93653 2.339,0 4.2527,-0.5625 4.2527,-1.25 z m 71.0117,-15.04216 c 0.3884,-6.7489 -2.5711,-16.20784 -5.071,-16.20784 -0.6489,0 -2.6791,1.06765 -4.5117,2.37256 -3.5724,2.5438 -24.8169,12.62744 -26.6038,12.62744 -2.5059,0 -0.4312,-2.76776 10.7998,-14.40764 6.5313,-6.76901 11.875,-12.66714 11.875,-13.10694 0,-3.11251 -17.0245,-12.73782 -25.1388,-14.21295 -5.8678,-1.06674 -16.5663,1.26199 -20.1593,4.38806 l -2.8269,2.45953 3.75,-0.63768 c 10.6037,-1.80314 16.0323,-2.1842 20.1395,-1.41369 l 4.5311,0.85005 -0.6539,6.47812 c -0.3597,3.56298 -1.6397,10.69689 -2.8446,15.85314 -2.2675,9.70432 -2.6432,14.57059 -1.2334,15.98033 0.9191,0.91909 34.364,6.43153 36.3113,5.98488 0.6875,-0.1577 1.4241,-3.31101 1.6367,-7.00737 z m -436.63667,-6.14168 c 7.5625,-0.62872 14.8235,-1.55771 16.13556,-2.0644 2.21094,-0.85381 2.13035,-1.12473 -1.10095,-3.70128 l -3.4865,-2.78004 3.91344,-0.76023 c 2.1524,-0.41811 5.69536,-1.10688 7.87325,-1.53061 6.88361,-1.33924 1.35376,-2.7873 -19.21778,-5.03241 -18.16338,-1.98229 -20.606,-1.98138 -40.41392,0.0151 -11.59518,1.16875 -21.37431,2.41718 -21.73143,2.77428 -1.0314,1.0314 2.75652,2.97321 5.84083,2.99421 4.62902,0.0315 3.1847,1.95514 -2.41509,3.21656 -6.1648,1.38869 -7.57076,3.86634 -2.86432,5.04758 9.47223,2.37737 39.37742,3.3251 57.46691,1.82116 z m 153.67633,-20.87488 c 4.80952,-0.65922 6.12504,-1.39998 7.11629,-4.00717 1.17768,-3.09751 1.70098,-18.85576 1.39672,-42.05911 -0.0811,-6.1875 -0.0444,-13.2069 0.0816,-15.59866 0.20493,-3.88996 -0.16645,-4.43473 -3.52091,-5.1646 -4.91515,-1.06948 -32.98116,-1.328 -37.87663,-0.34891 -2.09777,0.41954 -3.59876,1.40392 -3.33552,2.1875 0.26322,0.78357 0.76311,15.15663 1.11084,31.94013 0.34772,16.7835 1.07527,30.94904 1.61677,31.47896 1.94145,1.89999 23.58725,2.91834 33.41086,1.57185 z m -249.5836,-34.60669 c 0.33223,-20.19709 0.26529,-20.83459 -2.1875,-20.83459 -2.43703,0 -2.53023,0.75204 -2.53023,20.41666 0,11.22918 0.38672,20.80339 0.85937,21.27605 2.77665,2.77664 3.5372,-1.33489 3.85836,-20.85812 z m 17.62536,-38.21115 c 1.4301,-0.90588 1.47465,-3.15235 0.26577,-13.40259 -0.79877,-6.77286 -1.99379,-12.85577 -2.65559,-13.51757 -0.6618,-0.6618 -1.20327,-3.34078 -1.20327,-5.95328 0,-5.73808 -1.73657,-6.10215 -4.41364,-0.92529 -1.86339,3.6034 -4.73997,31.76011 -3.47231,33.98779 0.73397,1.28981 9.36885,1.14759 11.47904,-0.18906 z m 293.25126,-0.0739 c 0.83709,-1.35442 1.22809,-28.53798 0.88536,-61.55333 l -0.22971,-22.12872 -4.6875,-1.30178 c -5.07703,-1.40996 -19.24526,-1.73534 -23.68828,-0.54401 l -2.75077,0.73758 -0.0907,42.25651 c -0.0711,33.11495 0.25356,42.395 1.50077,42.89668 2.91682,1.17322 28.30744,0.85616 29.06085,-0.3629 z M 793.3993,343.28769 c 1.34418,-0.51581 1.5966,-1.09897 0.71227,-1.64552 -0.99072,-0.61229 -0.99298,-1.92746 -0.009,-4.75236 0.74886,-2.14819 1.11345,-5.20458 0.8102,-6.79198 -0.39513,-2.06833 -0.59962,-1.67596 -0.7216,1.38465 -0.27695,6.9486 -1.59958,3.47481 -2.30274,-6.04801 -0.77509,-10.49683 0.52099,-21.43329 2.22162,-18.74644 0.76534,1.20917 1.1287,0.0595 1.14175,-3.61266 0.0122,-3.2767 -0.46988,-5.08368 -1.23032,-4.6137 -0.6875,0.4249 -1.25,0.17684 -1.25,-0.55123 0,-0.72807 0.5625,-1.32377 1.25,-1.32377 2.1608,0 1.35906,-5.93481 -0.9375,-6.93971 -1.20313,-0.52645 -2.60938,-0.86789 -3.125,-0.75874 -1.61285,0.34141 -1.02412,-2.3935 0.9375,-4.35512 2.31892,-2.31893 2.3554,-3.53745 0.17128,-5.72158 -0.94081,-0.94081 -2.10805,-6.01847 -2.60665,-11.33929 l -0.90293,-9.63556 -4.26835,0 c -4.05977,0 -4.26835,0.21781 -4.26835,4.45718 0,2.45144 -0.62814,5.63086 -1.39586,7.06537 -0.76773,1.43451 -1.61685,7.98415 -1.88695,14.55477 -0.2701,6.57062 -1.04822,12.5037 -1.72914,13.18463 -1.62034,1.62034 -1.60984,6.11537 0.0125,5.11305 0.6875,-0.4249 1.25,0.1376 1.25,1.25 0,1.1124 -0.50356,1.71133 -1.11903,1.33095 -2.05973,-1.27299 -2.84961,3.54272 -0.82401,5.02388 2.25971,1.65233 2.60207,6.34216 0.51379,7.03825 -1.06883,0.35628 -1.07131,1.14523 -0.01,3.12858 1.82714,3.41404 1.56364,21.5963 -0.31336,21.62248 -0.7549,0.01 -0.52879,0.56441 0.50246,1.23086 2.10159,1.35815 16.16087,1.68541 19.37758,0.45105 z m 8.97632,-10.68542 c -0.39903,-0.99717 -0.69523,-0.70097 -0.7552,0.75521 -0.0542,1.3177 0.24115,2.05599 0.65652,1.64063 0.41537,-0.41538 0.45977,-1.4935 0.0986,-2.39584 z m -28.75,-8.75 c -0.39903,-0.99717 -0.69523,-0.70097 -0.7552,0.75521 -0.0542,1.31771 0.24115,2.05599 0.65652,1.64062 0.41537,-0.41536 0.45977,-1.49349 0.0986,-2.39583 z m 25.00777,-6.9531 c -0.31441,-1.20312 -0.57166,-0.21875 -0.57166,2.1875 0,2.40625 0.25725,3.39063 0.57166,2.1875 0.3144,-1.20312 0.3144,-3.17187 0,-4.375 z m 3.78365,-7.5 c -0.2864,-1.89062 -0.52074,-0.34375 -0.52074,3.4375 0,3.78125 0.23434,5.32813 0.52074,3.4375 0.28642,-1.89062 0.28642,-4.98437 0,-6.875 z m -7.54142,0.70313 c -0.39903,-0.99717 -0.69523,-0.70098 -0.7552,0.7552 -0.0542,1.31771 0.24115,2.05599 0.65652,1.64063 0.41537,-0.41537 0.45977,-1.49349 0.0986,-2.39583 z m 3.72396,-17.57813 c -0.34676,-0.85937 -0.63049,-0.15625 -0.63049,1.5625 0,1.71875 0.28373,2.42188 0.63049,1.5625 0.34676,-0.85937 0.34676,-2.26562 0,-3.125 z m 4.15301,-1.25 c -0.013,-2.76206 -0.36411,-3.51803 -1.09679,-2.36163 -0.98287,1.55127 -0.4999,6.42413 0.63672,6.42413 0.26356,0 0.4706,-1.82812 0.46007,-4.0625 z m -13.48086,-59.9375 c -1.16666,-1.16667 -1.8449,-1.1551 -3.05205,0.0521 -1.23608,1.23607 -1.17458,1.78535 0.30205,2.69795 2.50668,1.54921 4.77794,-0.72206 2.75,-2.75 z m 294.43747,146.92215 c 0.8594,-0.34676 2.2657,-0.34676 3.125,0 0.8594,0.34676 0.1563,0.63049 -1.5625,0.63049 -1.7187,0 -2.4218,-0.28373 -1.5625,-0.63049 z m 20.9375,-0.42215 c -0.4249,-0.6875 0.3857,-1.25 1.8013,-1.25 1.4155,0 2.5737,0.5625 2.5737,1.25 0,0.6875 -0.8105,1.25 -1.8012,1.25 -0.9907,0 -2.1489,-0.5625 -2.5738,-1.25 z m 15.3907,0.39611 c 0.9023,-0.36109 1.9804,-0.31669 2.3958,0.0986 0.4154,0.41536 -0.3229,0.7108 -1.6406,0.65652 -1.4562,-0.06 -1.7524,-0.35617 -0.7552,-0.7552 z"
-               style="fill:#3d3d3d" />
-            <path
-               sodipodi:nodetypes="cssssccsssssssscssssscsssssscsscscscsssscssssssscssssssssscsssssscscssssssssssssssscsssscssscsssssssscssssscsscsccscccsssccscssssscscscccssccccssscsscscssccscssscsscsssccssssccscsssssccsssscsscccsccsscsssssscscccscscscscscsscsssccsccccsccscsccsscsssscsccsssccssssscssssssssscsssssccccssscssssccsssscssssssccssscsscsccsssssssscsccssssscscssscccsccssssscssssscsssssscsssscssssccccscsscsssssscsssscsscsscssssssscssssssscssssssssscsscsscssssssccssscsssssssscssssssscssccscsscscsscssccscssssssssccssssscssscsccssssssssscssccsscsssssscscccssssscscsssssssssssssscsscssssssssscsscscscssssssssscccscssscccsscssssssccssssssssssssssscssssssssssssssssssscssssscssssccssscscscccssssssssssssssccsccsssssssssssssscccsscccccssssssccscccsccssscsssccccccsssscccscscsccscccsssssssssssscscssssssccsssscsssssssssssssssscsscssccccscccccccccccscssccccccsccccccsscssssssscscssssccssssccccccsscssccccsssscscssssssss"
+               id="path4204"
                inkscape:connector-curvature="0"
-               id="path4202"
+               sodipodi:nodetypes="csssscssssssssssssssssssssssscsssscsscscssssscssscsssscssssscsccssssscsscscccssssssccsssccsssssssscccsssssssccssssssssssscssssssccsssssssssssscscscsssccssccsssssssscssssssssssssscssssssscscsscsssssscssccssssscssscccccccssscccccccccccccscssssscsscscssscscsccccssssssssssssscccssccccsssssssssscsssssssccssscssscsscsscccscssscsscscsscssssscsccsssssssccsscsscssssssssscsssssssssssssscscccscsscccscccccccsssccsccssssscsssccsscscssscssscsscccccscssccccsccsssscscscscsssssssssssssssssssssccscsssccsssssssssscsssccscsssscscssssssscssscsssscccccssssssccsscscsssscccccsssscssssssccsscscsscsssssscsscsscscsssscssssssscsscccccccsscsssscssscccssssscscccsssssssssssscscsscsccccscsssscsssssssscssssscssssccscccccccccsccsssssscsccsccssssssssccsccccscsssssccccc" />
+            <path
+               style="fill:#2e2e2e"
                d="m 677.60372,714.75753 c -1.81115,-1.01711 -3.64163,-3.23831 -4.06773,-4.936 -1.81382,-7.2269 -4.50047,-36.39648 -4.80737,-52.19495 -0.18254,-9.39679 -0.80351,-17.55304 -1.37995,-18.125 -0.57643,-0.57195 -23.91664,-1.03991 -51.86714,-1.03991 -49.22105,0 -50.81932,-0.0752 -50.82694,-2.39239 -0.004,-1.31581 -0.71099,-2.62831 -1.57036,-2.91667 -0.91777,-0.30794 -1.5625,0.55028 -1.5625,2.0799 0,1.43229 -0.70313,2.59977 -1.5625,2.59441 -2.00415,-0.0125 -4.75094,-5.87046 -3.8516,-8.21411 0.41345,-1.07741 -2.28084,-4.96345 -6.76416,-9.75614 -8.81716,-9.42557 -12.20979,-15.93633 -14.81014,-28.4219 -1.05649,-5.0727 -2.94497,-10.3481 -4.19663,-11.7231 -2.02879,-2.22871 -2.31806,-5.4842 -2.66574,-30 -0.2145,-15.125 -0.27958,-34.68444 -0.14462,-43.46542 l 0.24539,-15.96544 5.03196,-5.45903 c 5.23526,-5.67958 17.34191,-12.71681 28.09304,-16.32963 10.20976,-3.43092 31.08333,-5.60507 54.0625,-5.63108 18.32249,-0.0207 21.5625,-0.30614 21.5625,-1.8994 0,-1.43606 -1.58616,-1.875 -6.77551,-1.875 l -6.7755,0 -0.81857,-7.8125 c -0.45021,-4.29687 -0.6356,-10.90625 -0.41198,-14.6875 0.38156,-6.45216 0.61778,-6.89931 3.84101,-7.27024 2.39972,-0.27615 3.65913,-1.2904 4.18017,-3.36645 0.92022,-3.66642 -0.0979,-5.4312 -3.98605,-6.90947 -2.39392,-0.91018 -3.03362,-2.09969 -3.1516,-5.8604 -0.0814,-2.59514 -0.0709,-5.17197 0.0234,-5.72627 0.0944,-0.5543 0.17679,-41.46487 0.18328,-90.91238 0.0112,-88.63571 0.0471,-89.92345 2.51318,-91.24326 3.68271,-1.97092 68.11378,-3.33221 66.92829,-1.41404 -0.49368,0.79888 -1.6464,1.45251 -2.56155,1.45251 -1.21938,0 -1.70071,2.41898 -1.80173,9.05459 -0.0757,4.98003 -0.48145,10.88628 -0.90143,13.125 l -0.76361,4.07041 7.95161,0.23342 c 11.85467,0.34799 27.84006,-0.37265 28.76002,-1.29655 1.00438,-1.00867 -1.61557,-13.66591 -3.53365,-17.07141 -1.14557,-2.03395 -0.93556,-3.09994 1.10821,-5.625 l 2.52167,-3.11546 45.79767,-0.38248 c 42.48061,-0.35478 57.68785,0.15898 55.95639,1.89045 -0.38249,0.38249 0.12845,1.8717 1.13544,3.30936 2.38047,3.39862 2.31443,6.47831 -0.23134,10.78797 -1.33185,2.25464 -1.70427,4.31511 -1.05155,5.81787 0.55585,1.27975 0.93984,2.69323 0.85329,3.14105 -0.59987,3.10396 51.04856,5.52102 67.54977,3.16123 l 7.16432,-1.02455 -0.47878,-13.20064 c -0.3347,-9.22793 -0.98604,-13.54704 -2.16431,-14.35165 -1.0429,-0.71217 8.95964,-1.00381 26.23495,-0.76494 23.78993,0.32896 28.13566,0.68034 29.375,2.37521 1.67372,2.28892 1.87585,117.60018 0.21299,121.51265 -0.5609,1.31971 -0.37212,2.86483 0.45055,3.6875 2.17318,2.17318 1.81412,20.39627 -0.47059,23.88319 -2.07713,3.17008 -1.83217,10.06406 0.43827,12.33449 0.93479,0.93479 1.44829,6.70109 1.44829,16.26332 l 0,14.81502 -3.8183,1.33106 c -3.27301,1.14098 -3.76392,1.87238 -3.4375,5.12141 0.36746,3.6576 1.66577,4.97538 6.3183,6.41305 1.81047,0.55947 2.1875,2.18325 2.1875,9.42122 0,7.46593 0.36571,8.94097 2.5,10.08321 1.60504,0.85899 2.5,2.61727 2.5,4.91162 l 0,3.57367 -9.80858,0.44542 c -5.86331,0.26628 -10.63973,1.13525 -11.875,2.16041 -3.2056,2.66043 -2.81902,16.50312 0.65515,23.45947 2.54536,5.09656 4.77843,7.05906 4.77843,4.19941 0,-0.6875 2.7793,-1.25 6.17623,-1.25 3.39692,0 6.52387,-0.5625 6.94877,-1.25 1.18553,-1.91822 5.625,-1.48318 5.625,0.55122 0,0.99068 -0.5625,2.14888 -1.25,2.57378 -2.01045,1.24253 -1.43695,4.375 0.80099,4.375 1.29776,0 -0.027,1.82909 -3.60722,4.98054 -6.03412,5.31146 -13.44377,15.82771 -13.44377,19.08027 0,1.08183 1.73066,3.4232 3.84591,5.20308 2.11524,1.77986 3.6584,3.23611 3.42924,3.23611 -0.22916,0 -2.28135,-0.53479 -4.56041,-1.18841 -3.99358,-1.14535 -4.21369,-1.02109 -6.07281,3.42843 -2.58171,6.17888 -1.48327,16.12902 2.73158,24.74384 3.23155,6.60506 15.69115,19.12906 22.68295,22.8002 4.40039,2.31048 16.65729,5.38589 18.04559,4.52786 1.6263,-1.00509 1.42342,-4.78644 -0.35205,-6.56192 -1.16666,-1.16666 -1.0465,-1.5 0.54076,-1.5 2.49695,0 4.21133,-4.74791 2.37679,-6.58245 -0.73193,-0.73193 -3.74094,-1.28149 -6.68666,-1.22123 -5.01249,0.1025 -5.13399,0.0285 -1.89495,-1.15536 3.16929,-1.15832 3.42598,-1.72949 3.04634,-6.77794 -0.29544,-3.92853 0.0571,-5.51302 1.22656,-5.51302 0.90263,0 1.72554,-1.125 1.82866,-2.5 0.10313,-1.375 0.24375,-3.15625 0.3125,-3.95834 0.0687,-0.80207 -0.66776,-1.72258 -1.63669,-2.04556 -1.2114,-0.4038 -1.5165,0.0517 -0.97672,1.45834 0.563,1.46718 0.0891,2.04556 -1.67582,2.04556 -3.48783,0 -3.08973,-1.09446 2.06675,-5.68195 2.49013,-2.21536 4.28958,-4.74175 3.99877,-5.61418 -0.52864,-1.58593 -18.25618,-7.45387 -22.51877,-7.45387 -2.76077,0 -2.7762,-0.34579 -0.23982,-5.37458 4.26377,-8.45362 8.58379,-11.49428 19.8573,-13.97661 2.89551,-0.63756 3.41622,-0.48602 2.28517,0.66505 -1.70333,1.73353 -0.82786,4.93614 1.34935,4.93614 3.67448,0 7.92798,3.16204 7.92798,5.89364 0,1.571 -0.51571,2.85636 -1.14601,2.85636 -2.42352,0 -5.76405,4.52762 -5.74693,7.78913 0.021,3.99981 1.18345,5.10457 7.51794,7.14491 5.35765,1.72571 5.67885,2.78636 2.18745,7.22487 -4.40609,5.6015 -3.37209,7.35449 9.0625,15.36395 6.3594,4.09623 12.5061,7.45432 13.6593,7.46242 2.7163,0.0191 7.2919,-5.81287 7.2308,-9.21636 -0.032,-1.76704 -2.342,-4.23754 -6.9658,-7.44893 -3.8051,-2.64277 -6.6694,-5.054 -6.3651,-5.35832 0.6687,-0.6687 13.391,4.24274 15.4791,5.97569 2.9225,2.42551 9.1492,-11.4912 9.1492,-20.44869 0,-3.41903 0.4826,-4.7763 1.5625,-4.39432 0.8934,0.31599 1.4306,2.20522 1.2545,4.41139 -0.2215,2.77353 0.4574,4.3949 2.4139,5.76531 2.5643,1.79609 2.6003,2.04116 0.6206,4.2287 -1.1558,1.27715 -2.1015,3.1295 -2.1015,4.11633 0,0.98681 -1.1174,4.85148 -2.4832,8.58813 -1.9162,5.24245 -2.1303,7.01519 -0.9375,7.7628 1.0122,0.63445 1.6881,0.0825 1.9583,-1.59911 0.2269,-1.4124 1.4797,-3.63521 2.7841,-4.9396 1.3044,-1.30438 2.043,-3.2281 1.6412,-4.27495 -0.4017,-1.04684 -0.1077,-1.90335 0.6534,-1.90335 0.7611,0 1.3837,-1.6875 1.3837,-3.75 0,-2.0625 0.4722,-3.75 1.0494,-3.75 0.5771,0 1.6901,-1.40625 2.4732,-3.125 0.7831,-1.71875 2.0182,-3.125 2.7446,-3.125 0.9185,0 0.9266,0.73647 0.027,2.41783 -2.4492,4.57623 -1.5376,8.72076 2.4515,11.14669 2.06,1.25279 3.3725,2.65077 2.9167,3.10663 -0.4559,0.45588 0.1276,0.82885 1.2966,0.82885 2.7169,0 10.4897,7.80884 8.4497,8.48884 -0.8189,0.27293 -2.6164,-0.9373 -3.9946,-2.68942 -3.3596,-4.27095 -5.797,-3.09845 -5.6002,2.69385 0.1574,4.6302 0.1598,4.63214 7.3169,5.88173 5.6336,0.98359 7.7973,2.04922 10.1524,5 1.6461,2.0625 3.4241,3.32231 3.9512,2.79959 0.527,-0.52274 -0.071,-1.70303 -1.3289,-2.62288 -1.258,-0.91985 -1.8869,-2.32029 -1.3975,-3.11209 1.3855,-2.24176 2.7148,-1.71643 4.2647,1.68538 0.9708,2.13062 2.4268,3.125 4.5757,3.125 1.8535,0 3.1518,0.71386 3.1518,1.73307 0,2.07112 -9.91,3.86072 -14.0691,2.54067 -2.4115,-0.7654 -2.5701,-0.62388 -1.1791,1.05221 1.3695,1.65012 1.0168,2.23111 -2.3846,3.92792 -2.9925,1.49284 -4.4143,1.64072 -5.6795,0.59069 -2.3081,-1.91559 -2.1677,-4.95029 0.1873,-4.0466 1.0312,0.39574 1.875,0.1889 1.875,-0.45962 0,-1.20399 -14.5972,-1.15783 -15.805,0.05 -0.3658,0.36583 0.6227,2.40713 2.1968,4.53622 2.5397,3.43514 3.3853,3.79303 7.5084,3.17806 2.5555,-0.38115 4.9914,-0.13472 5.4131,0.5476 0.4217,0.68234 1.5419,0.94318 2.4893,0.57963 0.9473,-0.36354 5.2424,1.08544 9.5446,3.21996 4.9418,2.45191 8.2594,3.44356 9.0099,2.6931 0.6533,-0.65331 2.9496,-0.97529 5.1029,-0.71549 11.0358,1.33152 16.6982,1.5564 18.0562,0.71712 1.1089,-0.68534 0.6814,-2.55239 -1.6256,-7.09969 -1.7216,-3.3934 -3.1325,-7.07834 -3.1354,-8.18875 0,-1.11041 -1.171,-3.50104 -2.5959,-5.3125 -2.5275,-3.2132 -2.5312,-3.2936 -0.153,-3.2936 1.3407,0 3.1379,0.84375 3.9937,1.875 0.8559,1.03125 2.6358,1.875 3.9554,1.875 1.3195,0 3.6067,1.125 5.0826,2.5 4.3703,4.07151 6.2312,2.67426 3.4241,-2.57089 -0.9486,-1.77247 -0.7739,-3.40051 0.6629,-6.17911 1.5287,-2.95611 1.6432,-4.3476 0.5289,-6.42952 -1.294,-2.41794 -2.1408,-2.58983 -9.4129,-1.91076 -6.5186,0.60872 -7.991,0.40939 -7.991,-1.08176 0,-1.00537 0.7812,-1.82796 1.7359,-1.82796 1.0161,0 2.1003,-1.9426 2.6147,-4.68464 0.963,-5.13315 2.3464,-6.51721 6.543,-6.54622 1.5226,-0.01 3.3963,-1.19225 4.1637,-2.62607 0.7673,-1.43381 3.7402,-5.01723 6.6064,-7.96317 10.0364,-10.31554 13.4453,-14.49231 12.7483,-15.62004 -0.9173,-1.48432 1.4565,-2.8996 5.4922,-3.2744 1.7715,-0.16451 6.3146,-1.223 10.0958,-2.3522 12.9992,-3.88195 30.6263,-1.71454 42.4637,5.22129 7.657,4.48639 16.4626,13.96546 20.0109,21.54123 1.624,3.46732 3.3993,6.30422 3.9451,6.30422 0.5458,0 1.5623,1.06489 2.2588,2.36641 0.9719,1.81602 0.6703,3.1243 -1.2967,5.625 -3.5116,4.4642 -4.5537,4.11977 -6.2146,-2.05391 -2.1187,-7.87517 -4.5411,-11.93949 -11.5047,-19.30249 -7.6593,-8.09853 -11.2818,-8.71592 -13.4044,-2.28445 -0.7897,2.39282 -1.0789,4.92804 -0.6427,5.63383 0.4362,0.7058 -0.08,1.61839 -1.1476,2.02797 -1.0673,0.40958 -2.4958,2.80659 -3.1744,5.32669 -0.7454,2.76823 -3.5313,6.79954 -7.0377,10.18398 l -5.8038,5.60197 0.875,-4.92336 c 1.1137,-6.26718 7.0596,-18.12433 9.1106,-18.1682 0.8594,-0.0184 1.5625,-0.83031 1.5625,-1.80428 0,-0.97395 -0.7031,-2.05455 -1.5625,-2.40131 -0.8593,-0.34676 -0.2829,-0.67489 1.281,-0.72916 1.8508,-0.0642 3.269,-1.218 4.0625,-3.30506 1.8318,-4.81814 1.6535,-5.18362 -4.2033,-8.61594 -4.0073,-2.34841 -7.1878,-3.17586 -12.1875,-3.17071 -12.0052,0.0125 -23.6402,4.90407 -23.6402,9.93902 0,1.61121 -1.2775,2.51545 -4.375,3.09653 -4.1241,0.77368 -4.375,1.10422 -4.375,5.76411 0,4.81622 0.1125,4.94336 4.375,4.94336 4.2122,0 5.7283,1.5161 3.125,3.125 -0.6875,0.4249 -1.25,1.90559 -1.25,3.29043 0,4.06696 -4.2458,2.32006 -4.9963,-2.05569 -0.5059,-2.94986 -1.3632,-3.818 -4.0792,-4.13095 -2.424,-0.2793 -3.681,0.274 -4.26,1.875 -0.4517,1.24916 -1.9526,3.90174 -3.3354,5.89459 -3.7282,5.37332 -4.4063,20.91171 -1.2973,29.73012 2.2774,6.45989 14.4137,21.0215 17.5202,21.0215 0.7174,0 2.3646,-1.96875 3.6604,-4.375 1.9828,-3.68184 3.0303,-4.375 6.6115,-4.375 4.2293,0 4.2513,-0.03 3.5973,-4.90572 -0.5439,-4.05544 -0.1392,-5.39317 2.3354,-7.7179 l 2.9934,-2.81217 0,5.14413 c 0,2.82926 -0.5462,5.48169 -1.2137,5.89426 -0.6676,0.41259 -1.5855,3.55215 -2.0398,6.97683 -0.8964,6.75727 -2.3309,8.85065 -3.3623,4.90651 -0.8582,-3.28164 -4.0185,-3.1625 -6.4027,0.24137 -2.2815,3.2573 -0.666,6.02269 3.5185,6.02269 1.4816,0 3.9347,0.86915 5.4513,1.93145 4.4587,3.12298 14.2454,3.69505 21.7934,1.27393 11.7284,-3.76207 11.7187,-4.65026 -0.2676,-24.49342 -9.4083,-15.57511 -9.665,-16.21196 -6.5352,-16.21196 2.4447,0 11.457,5.4279 12.9803,7.81782 0.4385,0.68788 0.5125,3.37357 0.1645,5.96822 -0.5256,3.91804 -0.176,4.96198 2.0625,6.15998 1.4824,0.79337 3.7931,1.09403 5.1349,0.66815 1.3722,-0.43551 3.661,0.0811 5.2309,1.18075 3.8933,2.72695 5.815,2.44599 7.424,-1.08543 0.7619,-1.67229 3.0656,-3.73653 5.1194,-4.5872 2.0537,-0.85068 5.0745,-2.99233 6.7128,-4.75922 l 2.9788,-3.21252 -0.017,3.73723 c -0.026,5.74801 -1.3339,9.36222 -3.3874,9.36222 -1.2912,0 -1.5808,0.67138 -0.9435,2.1875 0.5057,1.20313 1.1955,3.46123 1.5329,5.01801 0.4808,2.21833 0.1756,2.66252 -1.4107,2.05377 -2.6129,-1.00266 -2.6176,1.19217 -0.01,3.35859 2.5371,2.10563 1.7996,9.78617 -2.0391,21.23583 -5.4673,16.30702 -14.418,30.35472 -21.9128,34.39096 l -4.0726,2.19324 -10.4338,-5.23615 c -18.4572,-9.26285 -25.8687,-10.592 -61.6835,-11.06224 -17.1875,-0.22566 -32.8808,-0.96811 -34.874,-1.6499 -1.9932,-0.68179 -6.614,-1.23961 -10.2685,-1.23961 -5.3652,0 -6.9021,0.48135 -7.9825,2.5 -1.878,3.50918 -8.2666,3.33346 -11.3621,-0.3125 l -2.3879,-2.8125 -2.3878,2.8125 c -2.0537,2.41884 -3.6063,2.8125 -11.0929,2.8125 -4.7877,0 -11.0964,0.84375 -14.0193,1.875 -5.4215,1.91281 -13.5032,2.41022 -18.29,1.12571 -1.629,-0.43713 -3.4319,-2.66766 -4.6379,-5.73774 l -1.9729,-5.02258 -5.98709,0.88895 c -3.29289,0.48891 -21.13865,1.12786 -39.65725,1.41986 -21.70506,0.34225 -34.25381,1.01528 -35.3125,1.89391 -0.90327,0.74965 -1.64231,2.45649 -1.64231,3.79298 0,1.87077 -0.72809,2.33895 -3.16386,2.03444 -1.74013,-0.21754 -3.23385,-0.67678 -3.31938,-1.02053 -0.0855,-0.34375 0.25211,-9.53771 0.75034,-20.43101 1.07141,-23.42579 0.63596,-24.56899 -9.3586,-24.56899 -9.89198,0 -12.03739,1.8311 -7.721,6.58983 1.79342,1.97721 2.30009,5.59787 2.8125,20.09842 0.58972,16.68844 0.77914,17.75441 3.3559,18.88552 1.502,0.65933 3.31806,2.48746 4.0357,4.0625 0.94957,2.08409 2.35458,2.86373 5.1608,2.86373 3.59738,0 3.82973,0.27247 3.4643,4.0625 -0.36306,3.76554 -0.68866,4.03381 -4.4542,3.67004 -2.23437,-0.21585 -4.07865,-0.21585 -4.09839,0 -0.0198,0.21585 -0.858,9.59321 -1.8628,20.83858 -2.04668,22.90573 -3.37737,29.20494 -6.91725,32.74482 -3.07656,3.07656 -2.65548,3.08736 -36.87878,-0.9462 -26.3251,-3.10268 -32.5809,-3.38287 -76.18028,-3.41205 -47.14829,-0.0315 -58.58624,0.67706 -100.625,6.23415 -2.57274,0.34009 -5.73154,-0.18349 -7.66801,-1.27098 z m 202.62404,-10.58868 c 0.71168,-1.32981 1.28925,-3.72043 1.28347,-5.3125 -0.006,-1.59208 0.87932,-6.83218 1.96688,-11.64468 3.61882,-16.0135 4.11171,-18.72357 3.51406,-19.32123 -0.98313,-0.98312 -14.58507,-0.73628 -18.46349,0.33507 l -3.61805,0.99942 0.70415,10.8686 c 0.51911,8.01266 0.24974,11.6897 -1.02516,13.99338 -2.42194,4.37634 -2.24795,9.62505 0.36961,11.14964 1.20312,0.70076 4.83959,1.29121 8.08102,1.31211 4.57188,0.0295 6.1837,-0.5042 7.1875,-2.37981 z m 1.59673,-41.39522 c 5.72889,-1.59101 5.58552,-0.97763 6.55937,-28.06196 0.42022,-11.6875 1.0663,-22.46941 1.4357,-23.95979 1.03825,-4.1889 -3.55237,-5.91531 -15.90679,-5.98215 -14.30175,-0.0774 -17.03634,1.37399 -17.20663,9.13219 -0.0701,3.19536 0.77059,8.17611 1.86827,11.06832 1.39641,3.67932 1.70737,6.68254 1.03542,10 -0.52819,2.60779 -1.08079,5.58518 -1.22799,6.61643 -0.14721,1.03125 -0.44218,2.4375 -0.6555,3.125 -0.73995,2.38474 1.59435,15.66223 2.89487,16.46599 4.33426,2.67872 14.5388,3.44681 21.20328,1.59597 z m -176.54282,-4.3381 c 0.73683,-1.93804 0.77387,-6.14867 0.0963,-10.9375 -0.68179,-4.81797 -0.59819,-13.41599 0.21929,-22.55336 1.27771,-14.28173 1.23396,-14.85415 -1.33109,-17.41921 -2.28423,-2.28421 -3.309,-2.48999 -7.38579,-1.483 l -4.7336,1.16921 0.25544,8.125 c 0.14048,4.46875 0.48777,16.28125 0.77173,26.25 0.28397,9.96875 0.59089,18.54688 0.68207,19.0625 0.0911,0.51563 2.42969,0.9375 5.1967,0.9375 4.2273,0 5.22231,-0.50336 6.229,-3.15114 z m 199.36151,-0.58767 c 0.9498,-2.99257 -0.10135,-5.01119 -2.60945,-5.01119 -2.19636,0 -3.56471,3.00667 -2.55996,5.625 1.03297,2.6919 4.24112,2.31096 5.16941,-0.61381 z m 273.12852,-27.30285 c 0,-1.76125 -1.408,-2.56925 -3.2472,-1.86348 -2.6087,1.00105 -2.1189,2.90514 0.7472,2.90514 1.375,0 2.5,-0.46875 2.5,-1.04166 z m 6.7941,-2.83932 c -1.0908,-1.76491 -3.0441,-1.30498 -3.0441,0.71676 0,1.1151 0.7333,1.55438 1.8679,1.11901 1.0273,-0.39422 1.5566,-1.22032 1.1762,-1.83577 z m -130.7845,-8.50071 c 0.2595,-4.55906 -0.1471,-7.09387 -1.25,-7.79336 -2.6866,-1.7039 -14.1272,-1.2116 -18.9819,0.81682 -5.2331,2.18652 -5.6567,4.11474 -1.7152,7.80729 4.9151,4.60464 10.0309,6.61464 15.9375,6.26188 l 5.625,-0.33594 z m 144.0229,2.96761 c 1.3134,-1.58264 1.1776,-2.22506 -0.7845,-3.71023 -3.0217,-2.28721 -3.6003,-2.28729 -5.498,-6.9e-4 -1.2415,1.4959 -1.2415,2.2541 0,3.75 1.9913,2.39939 4.2705,2.38521 6.2825,-0.0391 z m 13.1264,-4.39067 c 0.8766,-1.41845 -1.5133,-4.94525 -3.3512,-4.94525 -2.0106,0 -2.7306,3.9652 -0.9273,5.10701 2.2991,1.45581 3.3022,1.41789 4.2785,-0.16176 z m -238.15887,-3.69525 c 0,-2.91666 -0.55555,-3.75 -2.5,-3.75 -1.78571,0 -2.5,0.83334 -2.5,2.91666 0,3.31204 0.92459,4.58334 3.33334,4.58334 1.01851,0 1.66666,-1.45834 1.66666,-3.75 z m -233.74764,-0.005 c 1.21021,-2.2613 2.16828,-2.42746 9.86932,-1.71172 5.78292,0.53746 8.81019,0.33765 9.40242,-0.62059 0.48039,-0.77729 3.75711,-1.41327 7.28161,-1.41327 4.85903,0 7.10754,-0.65703 9.30123,-2.71788 1.59119,-1.49485 2.89306,-2.05735 2.89306,-1.25 0,2.75676 2.49964,1.47619 2.6246,-1.34462 0.12213,-2.75796 0.14091,-2.75419 0.96592,0.19421 1.24877,4.46276 4.34308,5.97767 8.10141,3.96627 1.89827,-1.01593 4.7228,-1.35231 7.26887,-0.86569 8.30905,1.58808 23.08531,3.13443 30.58091,3.20031 6.58463,0.0579 7.75899,0.42026 8.32048,2.5674 0.35957,1.37501 1.4813,2.5 2.49274,2.5 1.93377,0 5.74532,-3.72976 3.86062,-3.77779 -0.5998,-0.0153 0.1567,-0.99967 1.68111,-2.1875 2.76999,-2.15839 2.77175,-2.18816 2.90942,-49.03471 0.0757,-25.78125 -0.2473,-47.85937 -0.7179,-49.0625 -0.59054,-1.50973 -0.25614,-2.1875 1.07931,-2.1875 1.06424,0 2.24499,0.50163 2.62391,1.11473 0.37891,0.6131 0.94056,18.11031 1.24811,38.88269 0.30757,20.77237 0.87449,38.08325 1.25984,38.4686 1.62336,1.62336 1.98001,-1.72128 2.57989,-24.19419 0.34717,-13.00575 0.93292,-32.2277 1.30169,-42.71544 0.67038,-19.06595 0.67003,-19.06906 -2.44842,-22.1875 l -3.11887,-3.11831 8.49302,0 8.49303,0 0.82245,30.9375 c 0.45235,17.01563 0.82366,38.10938 0.82515,46.875 0.003,14.67911 0.18551,15.9375 2.3179,15.9375 2.19936,0 2.36083,-2.48193 3.22774,-49.61251 l 0.91256,-49.61253 15.7594,-20.07497 c 22.96482,-29.25355 22.78511,-29.00752 22.78511,-31.19237 0,-1.14576 -1.02935,-2.00762 -2.39776,-2.00762 -3.62823,0 -6.35224,-1.3318 -6.35224,-3.10568 0,-0.87352 -0.88751,-2.32478 -1.97225,-3.22503 -1.76904,-1.46818 -1.6798,-1.85741 0.86604,-3.77775 l 2.83828,-2.14093 -4.92853,-1.38175 c -2.7107,-0.75997 -8.44417,-2.03858 -12.74104,-2.84137 -4.29688,-0.80279 -7.8125,-1.82616 -7.8125,-2.27415 0,-0.448 3.51562,-1.33515 7.8125,-1.97144 l 7.8125,-1.1569 0.79675,-6.25 c 0.43821,-3.4375 0.92367,-18.04264 1.07881,-32.45585 l 0.28208,-26.20585 -3.57883,-1.1801 c -1.96835,-0.64905 -18.38622,-1.31246 -36.48417,-1.47422 -33.77692,-0.30192 -45.89029,-1.11031 -47.1487,-3.14647 -0.39517,-0.63937 0.39371,-1.16251 1.75306,-1.16251 5.46744,0 6.426,-1.24296 6.426,-8.33251 0,-3.74827 -0.50083,-6.50551 -1.11294,-6.1272 -1.67356,1.03432 -2.9433,-7.72842 -1.48309,-10.23511 1.11077,-1.90681 1.2889,-1.78835 1.42075,0.94482 0.13734,2.847 0.25232,2.77435 1.29244,-0.81665 0.69871,-2.41229 0.68571,-5.07979 -0.0335,-6.875 -0.8681,-2.16682 -1.1959,-2.36172 -1.25442,-0.74585 -0.0436,1.20313 -0.64174,2.1875 -1.32924,2.1875 -0.6875,0 -1.25,-2.87268 -1.25,-6.38374 0,-5.16088 0.35917,-6.2459 1.875,-5.66423 1.26326,0.48476 1.875,-0.0593 1.875,-1.66749 0,-2.8765 2.03289,-4.42913 2.91955,-2.22983 0.3482,0.86366 0.67749,-4.25552 0.73176,-11.37595 0.084,-11.01981 -0.18031,-12.83917 -1.77631,-12.22673 -1.41234,0.54197 -1.91077,-0.27324 -2.02,-3.30376 -0.0797,-2.2128 -0.40225,-3.03889 -0.71666,-1.83577 -1.1946,4.57131 -2.88834,1.91417 -2.88834,-4.53125 0,-6.525 -0.11263,-6.74128 -3.90625,-7.5 -5.08289,-1.01658 -47.28017,-0.99236 -55.80917,0.032 -6.0193,0.72296 -6.51209,1.01991 -5.68645,3.42663 0.49718,1.4493 0.81296,4.04133 0.70171,5.76008 -0.11125,1.71875 -0.22512,6.60634 -0.25303,10.86132 -0.0279,4.25497 -0.55685,9.06743 -1.1754,10.69435 -1.0624,2.7943 -0.20876,10.38783 1.66888,14.84566 0.5011,1.18971 0.0168,2.86305 -1.1731,4.05291 -1.19199,1.19199 -1.61999,2.67401 -1.0393,3.59867 0.54301,0.86465 1.0008,8.59381 1.0173,17.1759 l 0.03,15.60382 4.62189,0.75126 c 2.54204,0.4132 5.45467,1.44241 6.47251,2.28714 1.58084,1.31198 24.51442,5.08736 31.0929,5.11858 1.48156,0.007 2.1875,0.99262 2.1875,3.05402 0,4.17606 2.21102,9.77586 4.56795,11.56911 1.51191,1.15032 2.55131,1.15032 4.58289,0 5.81883,-3.29475 7.31766,-6.39424 4.46938,-9.24251 -1.79287,-1.79288 5.24967,-5.15139 11.37978,-5.4269 10.77664,-0.48433 11.34067,-0.27647 11.1776,4.11917 -0.0829,2.23438 0.14021,6.42808 0.49578,9.31935 -98.08222,14.30032 3.30816,16.04181 -0.52883,37.14591 -0.91573,4.90162 -0.76818,6.56627 0.72861,8.22019 1.03226,1.14065 1.87685,2.67255 1.87685,3.40424 0,1.79862 2.64399,2.68917 11.04385,3.7198 l 7.08115,0.86882 -6.875,1.57483 c -12.25137,2.80635 -23.51,3.38065 -32.61074,1.66346 -7.34548,-1.38599 -10.99691,-1.32081 -25.21655,0.45011 -21.41561,2.66713 -27.42982,2.60989 -53.62688,-0.51035 -18.33013,-2.18324 -23.50144,-2.37603 -33.54583,-1.25071 -16.42758,1.84049 -35.89026,3.83185 -37.45074,3.83185 -0.71459,0 -1.29926,0.49573 -1.29926,1.10161 0,0.60588 2.67187,1.79731 5.9375,2.64763 l 5.9375,1.54602 -4.0074,1.41488 c -12.51939,4.42012 -3.26324,6.94152 29.0074,7.90167 20.63192,0.61387 43.67592,-0.75967 46.9774,-2.8001 0.848,-0.5241 0.59131,-1.60455 -0.7274,-3.06171 -2.92746,-3.2348 -1.09895,-3.89096 13.00926,-4.66836 12.1892,-0.67167 23.86574,0.28242 23.86574,1.95007 0,0.4832 -2.39063,1.93826 -5.3125,3.23348 l -5.3125,2.35493 3.83434,1.04157 c 2.10888,0.57285 9.70264,1.82987 16.875,2.79337 10.33435,1.38829 12.24411,1.93508 9.20242,2.63479 -20.58909,7.39476 -16.79218,27.3969 -18.85073,38.16751 -0.4942,2.47099 -0.24567,3.74263 0.73149,3.74263 0.81402,0 1.15374,0.52792 0.75495,1.17317 -0.39877,0.64525 0.24417,1.71558 1.42876,2.3785 3.41816,1.9129 -7.48242,2.65224 -47.10123,3.19466 l -35.625,0.48774 -0.32765,47.942 c -0.1802,26.3681 -0.0211,48.74075 0.35347,49.71699 0.41075,1.07039 1.12792,1.31986 1.80664,0.62846 1.07314,-1.09319 2.33311,-40.32224 2.47583,-77.08402 l 0.0667,-17.18749 9.0625,0.0191 c 9.16987,0.0194 13.83368,1.31593 11.01025,3.0609 -1.98881,1.22915 0.96879,4.76743 3.25251,3.89108 0.92111,-0.35345 2.54384,-0.30915 3.60608,0.0985 1.62596,0.62394 1.52715,1.02423 -0.625,2.53165 -1.40599,0.98479 -2.55403,2.1805 -2.55119,2.65714 0.002,0.47665 24.29279,0.99721 53.9777,1.15682 29.68491,0.15961 54.42406,0.74172 54.9759,1.29355 0.55184,0.55184 -22.4725,1.0206 -51.1652,1.04169 -28.6927,0.0211 -53.66476,0.42138 -55.49346,0.88951 -3.17,0.81151 -3.3634,1.33189 -4.15067,11.16812 -0.45416,5.67431 -0.64544,27.09141 -0.42508,47.59353 0.36496,33.95503 0.59559,37.38559 2.58816,38.49962 1.20313,0.67266 2.1875,2.22631 2.1875,3.45256 0,4.4829 4.10859,5.39748 6.25236,1.3918 z m 19.99764,-20.70694 c 0,-2.61592 0.5219,-3.13781 2.8125,-2.8125 1.80745,0.2567 2.95524,1.40449 3.21194,3.21194 0.32531,2.2906 -0.19658,2.8125 -2.8125,2.8125 -2.61592,0 -3.21194,-0.59602 -3.21194,-3.21194 z m 36.25,2.2316 c -3.80581,-1.30822 -3.41475,-3.28424 1.3302,-6.72146 4.6032,-3.33454 5.40112,-4.81747 6.61735,-12.2982 0.27942,-1.71875 0.32967,-0.13302 0.11163,3.52384 -0.21803,3.65685 -1.13617,7.53562 -2.04032,8.61947 -0.90413,1.08387 -2.2064,3.21945 -2.8939,4.74577 -0.7556,1.6775 -1.9916,2.52018 -3.125,2.13058 z m 17.8125,-2.19641 c -0.85938,-0.94475 -1.5625,-2.02272 -1.5625,-2.39549 0,-1.24638 3.59136,-0.69571 4.44231,0.68115 1.32754,2.14802 -1.14595,3.62047 -2.87981,1.71434 z m -30.3125,-36.19825 c 0,-1.30952 1.31945,-1.875 4.375,-1.875 3.05555,0 4.375,0.56548 4.375,1.875 0,1.30953 -1.31945,1.875 -4.375,1.875 -3.05555,0 -4.375,-0.56547 -4.375,-1.875 z m 2.44772,-8.22268 c -1.63516,-3.05532 -0.76178,-6.15232 1.73499,-6.15232 2.72079,0 4.86335,3.348 3.96133,6.19001 -1.04762,3.30075 -3.9198,3.28175 -5.69632,-0.0376 z m 35.05228,-264.27732 c 0,-3.78125 0.54127,-6.875 1.20284,-6.875 0.66156,0 1.16588,3.09375 1.12072,6.875 -0.0451,3.78125 -0.58645,6.875 -1.20284,6.875 -0.61639,0 -1.12072,-3.09375 -1.12072,-6.875 z m -2.91666,4.79167 c -1.32744,-1.32744 -0.96388,-10.41667 0.41666,-10.41667 0.6875,0 1.25,2.53125 1.25,5.625 0,5.723 -0.18976,6.26857 -1.66666,4.79167 z m 384.14753,326.14583 c -0.045,-2.22221 -2.1832,-4.30534 -3.0234,-2.94595 -0.4703,0.7609 -0.5074,1.94595 -0.082,2.63345 0.9011,1.45803 3.1338,1.68268 3.1059,0.3125 z M 606.52173,612.1379 c 0,-1.84074 -1.48926,-2.3953 -2.83054,-1.05402 -1.12679,1.12679 0.42475,4.3421 1.71152,3.54684 0.61546,-0.38037 1.11902,-1.50215 1.11902,-2.49282 z m 612.49997,-6.21545 c 0,-2.82549 -0.6942,-4.68065 -1.9289,-5.15443 -2.5937,-0.99533 -3.7513,0.36788 -2.0515,2.41599 0.7567,0.91176 1.0525,2.89411 0.6573,4.40521 -0.5212,1.99322 -0.1637,2.74745 1.3023,2.74745 1.4796,0 2.0208,-1.18226 2.0208,-4.41422 z m -277.49997,-8.71078 c 0,-2.3251 -0.5625,-4.5751 -1.25,-5 -0.76441,-0.47243 -1.25,1.46994 -1.25,5 0,3.53006 0.48559,5.47243 1.25,5 0.6875,-0.4249 1.25,-2.6749 1.25,-5 z m 141.24997,3.11064 c 0,-0.62975 -3.7968,-1.17563 -8.4375,-1.21305 -10.2713,-0.0829 -18.8373,-1.04659 -22.1875,-2.49629 -5.2843,-2.28664 -9.375,-2.63957 -9.375,-0.80885 0,0.97079 -0.8437,2.08885 -1.875,2.48459 -2.4917,0.95615 -2.3895,3.0132 0.1748,3.51881 4.5667,0.90041 41.7002,-0.42215 41.7002,-1.48521 z m -205.30602,-0.29814 c -0.60667,-1.8429 -12.19395,-2.89781 -12.19395,-1.11015 0,1.69868 2.33879,2.45909 7.91666,2.57396 3.30608,0.0681 4.6322,-0.38575 4.27729,-1.46381 z m -171.56895,-0.9375 c 0.43815,-0.70895 -0.61202,-1.25 -2.42623,-1.25 -1.75932,0 -3.19877,0.5625 -3.19877,1.25 0,0.6875 1.0918,1.25 2.42622,1.25 1.33443,0 2.77388,-0.5625 3.19878,-1.25 z m 496.87497,-3.5 c 0,-2.64941 -2.3104,-5.25 -4.6642,-5.25 -2.4073,0 -3.3746,3.4696 -1.5726,5.64091 2.1789,2.62543 6.2368,2.37108 6.2368,-0.39091 z m -292.45751,-4.9375 c 0.0234,-3.26562 0.3582,-12.17185 0.7441,-19.79161 0.60159,-11.87856 0.40455,-14.1512 -1.38175,-15.9375 -1.14586,-1.14587 -3.02757,-2.08415 -4.1816,-2.08509 -1.8928,-10e-4 -2.06352,1.98703 -1.7439,20.3125 0.19488,11.17281 0.5991,21.01733 0.89828,21.8767 0.29917,0.85938 1.6866,1.5625 3.08318,1.5625 2.18997,0 2.54507,-0.81669 2.58169,-5.9375 z m 223.70751,3.95435 c 0,-1.28195 -7.8844,-11.76685 -8.8484,-11.76685 -1.2249,0 3.7813,10.3645 5.5756,11.54336 1.6955,1.11395 3.2728,1.22166 3.2728,0.22349 z m -75.625,-5.51685 c 0.4249,-0.6875 0.1769,-1.25 -0.5512,-1.25 -0.7281,0 -1.3238,0.5625 -1.3238,1.25 0,0.6875 0.2481,1.25 0.5513,1.25 0.3031,0 0.8988,-0.5625 1.3237,-1.25 z m 65.4463,-3.72554 c -1.1576,-3.3207 -1.5036,-3.52066 -3.1842,-1.84015 -1.5032,1.50323 -1.5758,2.25838 -0.3581,3.72554 0.8399,1.01209 2.2728,1.84015 3.1841,1.84015 1.2957,0 1.3738,-0.81203 0.3582,-3.72554 z m -69.0625,-0.7517 c -0.4173,-1.08747 -0.7588,-2.49372 -0.7588,-3.125 0,-0.63126 -1.097,-1.14776 -2.4379,-1.14776 -1.3408,0 -3.0112,-0.98437 -3.7119,-2.1875 -0.7008,-1.20312 -1.2913,-1.53038 -1.3122,-0.72724 -0.021,0.80315 -0.3636,2.30882 -0.7616,3.34593 -0.4696,1.22375 0.5177,2.5584 2.8125,3.80218 4.6725,2.53245 7.1326,2.54817 6.1699,0.0394 z m -42.3213,-9.27213 c 0.1719,-3.4e-4 0.3125,-1.12563 0.3125,-2.50063 0,-1.76236 -0.8333,-2.5 -2.8243,-2.5 -1.5534,0 -3.5269,-1.125 -4.3856,-2.5 -2.1289,-3.40897 -8.48582,-3.37128 -10.32283,0.0612 -1.56909,2.93187 0.37618,10.64905 2.91556,11.56635 0.82071,0.29646 4.30467,-0.51068 7.74217,-1.79364 3.4375,-1.28296 6.3907,-2.33295 6.5625,-2.3333 z m 64.6875,-3.75063 c 0.4249,-0.6875 0.2101,-1.25 -0.4774,-1.25 -0.6875,0 -1.5977,0.5625 -2.0226,1.25 -0.4249,0.6875 -0.21,1.25 0.4775,1.25 0.6875,0 1.5976,-0.5625 2.0225,-1.25 z M 930.79449,538.32793 c 2.33029,-0.89421 2.62029,-5.59821 0.47724,-7.74126 -4.24286,-4.24286 -11.31146,0.74672 -8.5,6 1.34229,2.50809 4.33294,3.15719 8.02276,1.74126 z m -333.02276,-8.61626 c 2.32963,-1.71875 5.00929,-3.125 5.95479,-3.125 3.00668,0 1.25479,-5.57749 -1.89229,-6.02444 -1.54688,-0.21969 -2.8125,-0.90837 -2.8125,-1.5304 0,-1.89288 -7.19185,-4.9805 -9.60832,-4.12505 -1.24667,0.44133 -3.39168,1.78745 -4.76668,2.99136 -1.375,1.20393 -3.625,2.39148 -5,2.63902 -2.88066,0.51857 -4.32502,6.04951 -1.57979,6.04951 0.9455,0 3.62515,1.40625 5.95479,3.125 2.32963,1.71875 5.42338,3.125 6.875,3.125 1.45161,0 4.54536,-1.40625 6.875,-3.125 z M 725.67184,415.42029 c 0.56381,-0.55486 1.23894,-14.87157 1.50026,-31.81489 0.26134,-16.94334 0.79202,-31.31874 1.17928,-31.94534 1.16445,-1.88414 -12.69456,-2.97364 -26.75358,-2.1032 -19.10761,1.18301 -18.55893,0.91098 -17.50776,8.68026 0.4818,3.561 0.63224,14.6308 0.33431,24.59955 -0.61652,20.62939 -0.49406,31.57522 0.36285,32.43214 2.41214,2.41213 38.45187,2.54567 40.88464,0.15148 z M 631.2914,404.21006 c 1.8476,-0.9887 2.09399,-3.61881 2.01276,-21.48466 -0.0769,-16.9027 -0.41932,-20.56416 -2.0176,-21.57233 -1.05877,-0.66785 -2.84523,-0.86115 -3.96993,-0.42956 -1.77769,0.68216 -2.0449,3.45222 -2.0449,21.19894 0,22.41451 0.73022,25.11813 6.01967,22.28761 z m 24.51239,-58.42947 5.88099,-0.80608 -0.6153,-12.00642 c -0.33841,-6.60353 -0.91805,-16.78767 -1.28809,-22.63142 -0.97957,-15.46991 -1.2355,-25.33478 -0.90395,-34.84397 0.10488,-3.00793 -0.33247,-6.10168 -0.9719,-6.875 -0.63944,-0.77332 -1.353,-3.09353 -1.5857,-5.15603 l -0.42311,-3.75 -10.01111,-0.35818 c -16.10428,-0.57619 -14.91643,-3.98513 -15.39685,44.18658 -0.32873,32.96083 -0.0859,41.11023 1.25,41.95719 1.97581,1.25264 15.80523,1.41546 24.06502,0.28333 z m 288.76156,-0.41298 3.20638,-1.21906 -0.0138,-37.21844 c -0.016,-43.39657 -0.30839,-46.29144 -4.8534,-48.05868 -3.87094,-1.50514 -22.91161,-1.8911 -51.58614,-1.04566 l -20.8283,0.6141 -0.28057,20.0109 c -0.4122,29.40039 -0.17654,63.31386 0.4443,63.9347 0.2975,0.29749 9.68803,1.06304 20.86787,1.7012 11.17984,0.63816 20.6284,1.46174 20.99683,1.83015 1.1848,1.18481 28.7275,0.71279 32.0468,-0.54921 z M 876.7561,271.50855 c 0.30079,-0.90235 1.28515,-1.88672 2.1875,-2.1875 0.9375,-0.3125 1.40625,0.15625 1.09375,1.09375 -0.30078,0.90234 -1.28516,1.88671 -2.1875,2.1875 -0.9375,0.3125 -1.40625,-0.15625 -1.09375,-1.09375 z m -1.48437,-7.28814 c 0,-0.61395 0.84375,-1.44005 1.875,-1.83577 1.14214,-0.43828 1.875,-0.002 1.875,1.11626 0,1.00967 -0.84375,1.83577 -1.875,1.83577 -1.03125,0 -1.875,-0.50232 -1.875,-1.11626 z m -50.87439,64.4404 c 0.3537,-0.92171 0.14124,-2.46859 -0.47212,-3.4375 -0.81163,-1.28208 -1.12042,-0.82587 -1.13435,1.67586 -0.0208,3.73279 0.59215,4.40493 1.60647,1.76164 z m -0.75937,-19.23785 c -0.31693,-1.21621 -0.59708,-0.52379 -0.62255,1.53871 -0.0255,2.0625 0.23382,3.05758 0.57623,2.21129 0.3424,-0.84629 0.36324,-2.53379 0.0464,-3.75 z m -3.75458,-50.02379 c -0.31441,-1.20312 -0.57166,-0.21875 -0.57166,2.1875 0,2.40625 0.25725,3.39063 0.57166,2.1875 0.3144,-1.20312 0.3144,-3.17187 0,-4.375 z m -29.86166,-24.3125 c 3.16032,-3.16032 0.21939,-6.86913 -4.125,-5.20203 -2.25889,0.86681 -2.42372,3.15331 -0.375,5.20203 1.87982,1.87983 2.62017,1.87983 4.5,0 z m 309.62497,354 c -0.4249,-0.6875 -0.1768,-1.25 0.5513,-1.25 0.728,0 1.3237,0.5625 1.3237,1.25 0,0.6875 -0.248,1.25 -0.5512,1.25 -0.3032,0 -0.8989,-0.5625 -1.3238,-1.25 z m -16.7744,-3.86734 c -2.2437,-0.89681 -2.6607,-1.57256 -1.6154,-2.61778 1.0452,-1.04523 1.9025,-0.99929 3.3209,0.17794 1.0517,0.87278 2.763,1.26034 3.803,0.86126 1.1589,-0.44472 1.8909,-0.015 1.8909,1.11015 0,2.07383 -2.9204,2.25871 -7.3994,0.46843 z m -20.7644,-1.19543 c -1.1877,-1.92186 0.4392,-3.16184 2.0436,-1.55748 0.8977,0.89773 0.9193,1.5969 0.066,2.12455 -0.6999,0.43256 -1.649,0.17738 -2.1091,-0.56707 z m 38.1638,-3.68723 c 0,-0.6875 0.5625,-1.25 1.25,-1.25 0.6875,0 1.25,0.5625 1.25,1.25 0,0.6875 -0.5625,1.25 -1.25,1.25 -0.6875,0 -1.25,-0.5625 -1.25,-1.25 z m 67.5,-7.27318 c 0,-1.51068 2.3715,-3.27198 3.2384,-2.40512 0.3146,0.31463 -0.2853,1.28358 -1.3332,2.15322 -1.1879,0.98594 -1.9052,1.08078 -1.9052,0.2519 z m -91.8053,-6.36402 c -0.3865,-0.62545 -0.3502,-2.05599 0.081,-3.17896 0.7198,-1.87588 0.974,-1.8693 3.129,0.081 1.2901,1.16747 2.3456,2.59801 2.3456,3.17896 0,1.42076 -4.6692,1.35275 -5.5553,-0.081 z m 82.6782,-11.02705 c -7.1607,-3.82285 -8.1468,-4.72645 -6.25,-5.72697 1.2387,-0.65339 3.9957,-2.82978 6.1267,-4.83642 l 3.8745,-3.64842 4.563,8.68332 c 2.5096,4.77583 4.5629,9.02294 4.5629,9.43803 0,1.81487 -4.9954,0.29823 -12.8771,-3.90954 z m -78.2742,1.43509 c 0.06,-1.45619 0.3562,-1.75238 0.7552,-0.75521 0.3611,0.90233 0.3167,1.98047 -0.099,2.39583 -0.4154,0.41536 -0.7108,-0.32292 -0.6565,-1.64062 z m -106.29862,-2.50769 c -0.0375,-2.89072 0.70442,-4.20563 2.95024,-5.22889 2.92915,-1.33461 4.49971,-0.92481 4.49971,1.17408 0,0.57291 -0.82579,1.04166 -1.83508,1.04166 -1.00929,0 -2.67427,1.54688 -3.69996,3.4375 l -1.86486,3.4375 -0.05,-3.86185 z m 106.19872,-10.23987 c 7e-4,-0.88097 -0.9831,-1.95234 -2.1863,-2.38085 -1.2031,-0.42853 -4.5321,-2.66087 -7.3978,-4.96078 -2.8657,-2.29991 -5.6782,-4.1967 -6.25,-4.21509 -0.5718,-0.0184 -2.6464,-3.20938 -4.6102,-7.09111 -4.5238,-8.94199 -6.0028,-24.08931 -2.9497,-30.20942 1.0676,-2.13998 2.3153,-5.59487 2.7728,-7.67753 0.4659,-2.12161 3.6668,-6.66167 7.2794,-10.32507 3.5462,-3.59614 7.0148,-7.60822 7.7079,-8.91573 1.5024,-2.83431 5.2033,-5.34621 6.2842,-4.26527 0.423,0.42293 -0.6751,3.61872 -2.44,7.10172 -1.765,3.48301 -3.2091,7.45949 -3.2091,8.83663 0,2.40812 0.1704,2.38828 4.4541,-0.51872 8.8235,-5.98777 25.3655,-5.95698 34.3304,0.0639 8.396,5.63882 12.4655,14.4294 12.4655,26.92679 0,5.73817 0.5224,9.85726 1.25,9.85726 0.6875,0 1.25,0.84375 1.25,1.875 0,1.03125 0.5625,1.875 1.25,1.875 3.5849,0 -1.4455,9.53135 -8.0934,15.33503 -8.2499,7.20218 -13.1291,8.89007 -27.7551,9.60149 -11.0333,0.53668 -14.1537,0.33533 -14.1527,-0.91325 z m -2.223,-8.71078 c 0.7731,-2.98097 -0.1493,-5.3125 -2.1019,-5.3125 -2.3817,0 -4.8142,3.42991 -3.9779,5.60909 0.9977,2.59995 5.3841,2.38597 6.0798,-0.29659 z m 23.9898,-1.06848 c 3.2477,-1.24625 0.9077,-2.99317 -4.0268,-3.00623 -6.5196,-0.0172 -16.604,-5.08195 -21.1854,-10.63992 -6.079,-7.37492 -7.7712,-19.02671 -4.4891,-30.91037 1.1294,-4.08918 -2.0216,-2.20929 -3.9225,2.34015 -2.9052,6.95322 -2.4091,17.48293 1.1708,24.84735 4.6816,9.63089 9.0209,13.48169 19.4374,17.24942 2.6289,0.9509 10.657,1.02467 13.0156,0.11963 z m 6.6148,-9.95259 c 8.1266,-4.76251 12.8696,-11.96424 12.8696,-19.54106 0,-7.72568 -2.1528,-11.88201 -9.5077,-18.35611 -6.4123,-5.64432 -13.6597,-8.24541 -19.4379,-6.9763 -4.4249,0.97188 -16.9822,13.23825 -18.0963,17.67697 -2.4111,9.60663 2.765,22.41708 11.2558,27.85708 5.8264,3.733 15.9157,3.44218 22.9165,-0.66058 z m 44.1196,9.49884 c 0,-2.00867 0.504,-2.27329 2.7482,-1.44311 4.0006,1.47994 4.2993,3.90284 0.481,3.90284 -2.3782,0 -3.2292,-0.64819 -3.2292,-2.45973 z m -113.607,-15.35277 c -1.9505,-4.31349 -6.3389,-9.88228 -12.8052,-16.24945 -10.1319,-9.97656 -12.0107,-13.04344 -7.0253,-11.46742 7.395,2.33772 17.1376,12.97796 22.5926,24.67428 3.0867,6.61823 3.4214,9.60509 1.0763,9.60509 -0.479,0 -2.2063,-2.95312 -3.8384,-6.5625 z m -86.39297,-2.57359 c 0,-2.42552 3.39896,-6.63161 4.48301,-5.54756 1.06829,1.06827 -1.86376,7.18365 -3.44423,7.18365 -0.57133,0 -1.03878,-0.73624 -1.03878,-1.63609 z m 13.08176,-4.54396 c 1.20671,-1.95249 -1.59631,-5.06995 -4.55859,-5.06995 -2.97233,0 -2.11425,-1.55285 2.78638,-5.0424 l 3.73395,-2.65881 1.89301,4.53064 c 2.0665,4.94581 1.73924,6.20337 -2.15697,8.28856 -1.92089,1.02802 -2.35521,1.01574 -1.69778,-0.048 z m 195.66821,-5.06995 c -1.6023,-1.03554 -1.5569,-1.2145 0.3125,-1.23086 1.2032,-0.01 2.1875,0.54336 2.1875,1.23086 0,1.52451 -0.141,1.52451 -2.5,0 z m 4.7657,0.39611 c 0.9023,-0.36108 1.9804,-0.31668 2.3958,0.0986 0.4154,0.41536 -0.3229,0.7108 -1.6406,0.65652 -1.4562,-0.06 -1.7524,-0.35617 -0.7552,-0.7552 z m -5.6859,-6.67582 c -5.3057,-2.35778 -10.3159,-8.54 -10.3251,-12.74038 -0.01,-3.71243 3.9749,-10.68035 7.0441,-12.32289 4.3198,-2.31192 5.0109,-0.52846 1.9235,4.96465 -3.2373,5.76014 -3.4065,8.5952 -0.7399,12.40224 1.5955,2.27792 3.0124,2.77685 7.2614,2.5569 2.9035,-0.1503 5.9036,0.11275 6.6669,0.58445 1.6539,1.02221 5.3393,-2.34581 5.3393,-4.87955 0,-0.98213 0.8438,-1.78571 1.875,-1.78571 2.4498,0 2.4061,4.27746 -0.082,8.07545 -1.9354,2.95381 -7.7903,5.7573 -11.6665,5.58625 -1.1006,-0.0485 -4.3839,-1.1472 -7.2962,-2.44141 z m 59.021,-18.73954 c -2.6086,-2.07309 -6.6531,-4.94975 -8.9876,-6.39259 -5.0247,-3.1054 -4.6628,-4.58297 0.4721,-1.92763 3.6847,1.90543 15.383,11.94721 14.0241,12.03821 -0.4211,0.0281 -2.8999,-1.6449 -5.5086,-3.71799 z m -45.0246,-4.36611 c -2.0357,-1.6636 -3.0604,-3.04497 -2.2771,-3.06969 1.8703,-0.059 7.5217,4.54311 6.6521,5.41714 -0.3706,0.3725 -2.3394,-0.68385 -4.375,-2.34745 z m -200.57617,0.24038 c 0,-3.06597 1.82064,-3.46733 7.04314,-1.55265 2.65752,0.97432 3.9178,1.81111 2.80061,1.85956 -1.11719,0.0484 -3.78906,0.43963 -5.9375,0.86932 -3.04464,0.60893 -3.90625,0.34947 -3.90625,-1.17623 z m 19.375,-0.85502 c -0.4249,-0.6875 -0.17685,-1.25 0.55123,-1.25 0.72807,0 1.32377,0.5625 1.32377,1.25 0,0.6875 -0.24805,1.25 -0.55123,1.25 -0.30317,0 -0.89887,-0.5625 -1.32377,-1.25 z m 84.82667,-17.71352 c -3.7529,-1.817 -4.5387,-8.64567 -2.3257,-20.21164 2.0003,-10.45464 4.8554,-16.98397 10.2082,-23.3455 3.7946,-4.50955 14.2557,-11.62015 19.1658,-13.0273 2.7066,-0.77564 2.5993,-0.5614 -0.8011,1.59988 -3.96,2.51698 -6.1172,4.94646 -5.2034,5.86021 0.2727,0.27268 3.5634,-0.32057 7.3127,-1.31833 3.7492,-0.99777 8.8483,-1.8208 11.3312,-1.82896 l 4.5143,-0.0149 0.2441,18.63243 c 0.135,10.30936 -0.2706,18.95042 -0.9079,19.34432 -0.6335,0.39155 -8.6811,-1.82011 -17.8834,-4.91479 -9.2023,-3.09467 -17.8565,-5.4715 -19.2315,-5.28182 -4.7161,0.65056 -6.1707,14.57826 -2.4838,23.78236 0.9807,2.44805 -0.01,2.62911 -3.9395,0.72398 z m 85.0831,-0.19592 c -0.3502,-0.91269 -0.051,-3.19931 0.6642,-5.08137 1.7643,-4.64042 1.5475,-15.38755 -0.4216,-20.8973 -1.6777,-4.69454 -10.8309,-17.26959 -15.951,-21.9142 -5.8796,-5.33358 -16.2472,-9.66618 -25.3636,-10.5993 l -8.8378,-0.90462 10.625,0.29025 c 22.0346,0.60194 37.4159,13.01298 44.1353,35.61243 3.1822,10.70262 3.8768,17.43522 2.2405,21.71605 -1.3987,3.65945 -5.9328,4.79635 -7.091,1.77806 z m -145.5298,0.0969 c 0.024,-1.53979 7.8327,-41.29929 8.8597,-45.11342 1.5233,-5.65708 3.9517,-9.92424 8.4719,-14.88658 6.0758,-6.67016 6.821,-3.57169 1.7676,7.34895 -4.6505,10.0498 -8.2798,31.33478 -5.9625,34.96888 2.1742,3.40975 -0.2614,14.70026 -3.6755,17.03803 -1.2127,0.83038 -9.4731,1.39276 -9.4612,0.64414 z m 106.9409,-3.71564 c -2.0693,-2.95431 -2.5609,-6.69418 -1.0063,-7.65497 1.6673,-1.03049 27.8104,8.20536 27.8104,9.82488 0,0.33453 -5.5931,0.60823 -12.4291,0.60823 -11.4269,0 -12.586,-0.22402 -14.375,-2.77814 z m -81.3209,-63.47186 c 0.4249,-0.6875 1.0206,-1.25 1.3238,-1.25 0.3032,0 0.5512,0.5625 0.5512,1.25 0,0.6875 -0.5957,1.25 -1.3237,1.25 -0.7281,0 -0.9762,-0.5625 -0.5513,-1.25 z"
-               style="fill:#2e2e2e" />
-            <path
-               sodipodi:nodetypes="csssscscssssssssssssscssscsssssssssscsscscsscsssssssscssssccssssscccsssssssssssssssscscsssssssssssscsssssccssssscsssscssssssscscscsssssssssssscssssssssssscssssssssssscssssssssssssssssscscsscssssssscccccssscssssssssssssscssscsccssccssscsscccsssscssssscssscssscsssscscssscsssscssssssssssssssssssssssssssscsssssscccssssscsssssssssssssscsscccscssssccsssssccssscscsssscssscscccssccssccsssssccscsssssccsccssssssssscsssssssssssssssssssssscscsssscssssssssccsccsscccssssscsssscsscsscsssssssssscscccssssscsssssssscssscsssssccccsccscssssssssssssccssscccsssssscssssssccccccscccccscccccsccsssscsccccccscccsccccccccsscccsssscscsccssccscccccssssccsccccssssscssccssssscscscsscsssscscccsscssssssscssscssssssccsscssssssccccccc"
+               id="path4202"
                inkscape:connector-curvature="0"
-               id="path4200"
+               sodipodi:nodetypes="cssssccsssssssscssssscsssssscsscscscsssscssssssscssssssssscsssssscscssssssssssssssscsssscssscsssssssscssssscsscsccscccsssccscssssscscscccssccccssscsscscssccscssscsscsssccssssccscsssssccsssscsscccsccsscsssssscscccscscscscscsscsssccsccccsccscsccsscsssscsccsssccssssscssssssssscsssssccccssscssssccsssscssssssccssscsscsccsssssssscsccssssscscssscccsccssssscssssscsssssscsssscssssccccscsscsssssscsssscsscsscssssssscssssssscssssssssscsscsscssssssccssscsssssssscssssssscssccscsscscsscssccscssssssssccssssscssscsccssssssssscssccsscsssssscscccssssscscsssssssssssssscsscssssssssscsscscscssssssssscccscssscccsscssssssccssssssssssssssscssssssssssssssssssscssssscssssccssscscscccssssssssssssssccsccsssssssssssssscccsscccccssssssccscccsccssscsssccccccsssscccscscsccscccsssssssssssscscssssssccsssscsssssssssssssssscsscssccccscccccccccccscssccccccsccccccsscssssssscscssssccssssccccccsscssccccsssscscssssssss" />
+            <path
+               style="fill:#101010"
                d="m 884.02173,715.15066 c -4.46875,-0.47937 -19.375,-2.12368 -33.125,-3.65405 -36.36559,-4.0475 -94.32719,-4.06688 -130.625,-0.0438 -40.87875,4.53095 -40.23186,4.50351 -43.3898,1.84036 -3.57441,-3.01436 -6.09536,-20.88101 -7.2957,-51.70661 -0.46849,-12.03125 -1.1016,-22.29688 -1.40693,-22.8125 -0.30531,-0.51563 -23.26405,-0.9375 -51.01941,-0.9375 l -50.46428,0 -0.39944,-2.79973 c -0.4423,-3.10014 -4.55837,-4.57242 -6.0474,-2.16312 -1.42833,2.31107 -3.58774,0.32517 -2.82364,-2.59677 0.49982,-1.91128 -1.03147,-4.21706 -6.06304,-9.12956 -8.28261,-8.08655 -14.14177,-18.83619 -16.11235,-29.56076 -0.8211,-4.46875 -2.55831,-9.6491 -3.86046,-11.51189 -2.2119,-3.16421 -2.36755,-6.21433 -2.36755,-46.39392 0,-48.5431 -0.58445,-45.53315 10.38411,-53.47874 7.83768,-5.67759 7.99916,-4.23859 0.31269,2.78641 -5.53263,5.05653 -7.0269,7.22369 -7.11051,10.3125 -0.49344,18.23051 -0.003,31.88851 1.22766,34.188 0.94512,1.76598 1.01046,2.96313 0.18943,3.47055 -2.19114,1.3542 -1.3506,6.21502 1.36834,7.91301 1.44195,0.90052 2.95271,1.30632 3.35724,0.90178 0.40453,-0.40452 1.15595,-4.24038 1.66981,-8.5241 0.72328,-6.02953 0.51018,-8.44363 -0.94353,-10.68881 -1.69661,-2.62035 -1.6584,-3.22348 0.39597,-6.25 l 2.27379,-3.34979 0.41022,4.375 c 0.22563,2.40625 1.14347,5.21875 2.03965,6.25 2.61638,3.01069 3.63785,7.69147 1.91135,8.75851 -1.12547,0.69558 -0.82963,1.64808 1.11624,3.59395 2.90445,2.90445 3.31232,4.58914 1.39754,5.77254 -2.48821,1.5378 -1.10808,5.04194 2.73041,6.93251 3.56431,1.75553 3.95376,2.52824 4.25259,8.4375 0.18092,3.57774 -0.19124,6.50499 -0.82703,6.50499 -1.85051,0 -1.33316,4.54684 0.71033,6.24277 1.02646,0.85189 3.69834,1.70285 5.9375,1.89103 2.23916,0.18817 4.44421,0.4038 4.90012,0.47916 0.45591,0.0754 0.19538,1.81548 -0.57895,3.8669 -1.21587,3.22121 -1.07321,3.98289 1.04608,5.58525 1.34967,1.02046 1.9632,1.87326 1.36339,1.89514 -0.5998,0.0219 -0.4844,0.77012 0.25646,1.6628 1.37884,1.6614 12.42437,1.973 14.93505,0.42133 0.72284,-0.44675 2.7478,-0.26723 4.4999,0.39892 1.75211,0.66614 3.4747,0.74348 3.82798,0.17186 0.35328,-0.57162 3.04507,-0.57463 5.98175,-0.006 7.54817,1.45939 8.46442,1.37999 8.46442,-0.73391 0,-1.25 1.25,-1.875 3.75,-1.875 2.28244,0 3.75,0.64905 3.75,1.65851 0,1.07919 1.20071,1.50975 3.4375,1.23263 1.89062,-0.23424 4.50534,0.4081 5.81047,1.42742 1.96161,1.532 2.09759,2.18513 0.78446,3.76736 -1.26589,1.52531 -1.27367,2.29348 -0.0383,3.78202 1.27358,1.53456 1.02204,2.30796 -1.40943,4.33341 -2.92414,2.43585 -2.92752,2.46598 -0.28094,2.50706 1.47332,0.0229 3.00254,-0.80216 3.39827,-1.83341 0.39573,-1.03125 1.86216,-1.875 3.25874,-1.875 3.11119,0 3.58588,-5.54004 0.61705,-7.20148 -1.48421,-0.83061 -1.64467,-1.77038 -0.70424,-4.12461 0.66988,-1.6769 1.26222,-2.48641 1.31633,-1.79891 0.0541,0.6875 0.52043,0.58635 1.03628,-0.22478 0.51586,-0.81112 0.83663,-12.48109 0.71283,-25.93327 -0.12375,-13.45219 0.24094,-26.00729 0.81051,-27.90022 1.3613,-4.52424 1.32893,-5.20097 1.73385,36.24023 0.30099,30.80425 0.78137,37.70926 2.49333,35.83888 0.2622,-0.28646 0.88417,-32.72396 1.38219,-72.08334 l 0.90546,-71.5625 -7.46863,0 -7.46863,0 -0.77479,-4.6875 c -0.42614,-2.57812 -0.78099,-8.69531 -0.78855,-13.59375 -0.0136,-8.81696 0.0222,-8.91346 3.58531,-9.62606 6.33,-1.266 6.34916,-10.84269 0.0216,-10.84269 -2.68978,0 -3.99783,-3.89361 -3.40036,-10.12174 0.39901,-4.1594 0.48037,-4.2121 5.88907,-3.81496 3.58932,0.26355 5.85037,-0.17454 6.54336,-1.2678 1.30335,-2.05617 1.41886,-39.85459 0.128,-41.8839 -1.43121,-2.24994 -7.57255,-3.39058 -9.52609,-1.76928 -3.74527,3.1083 -4.5398,-7.09189 -0.81498,-10.46281 2.0746,-1.87749 4.74063,-2.18642 17.8125,-2.06411 8.455,0.0791 19.02898,-0.47006 23.49773,-1.2204 4.46875,-0.75033 9.8125,-1.45554 11.875,-1.56711 3.74174,-0.20244 3.75083,-0.2217 4.12198,-8.74409 0.31805,-7.303 0.63516,-8.32276 2.1875,-7.03444 2.18887,1.8166 2.3393,6.18344 0.36248,10.5221 -1.81557,3.98473 -0.80471,5.02725 4.99588,5.1524 2.52019,0.0544 8.51966,0.2733 13.33216,0.48652 l 8.75,0.38766 -7.5,0.99883 c -4.125,0.54938 -13.33521,1.55315 -20.46714,2.23064 -7.13193,0.67749 -13.53117,1.7958 -14.22052,2.48515 -1.59736,1.59736 -2.60762,45.59609 -1.29483,56.39189 1.09551,9.00887 1.07797,8.99595 14.53456,10.71145 3.32864,0.42435 5.82856,0.99504 5.5554,1.2682 -0.27316,0.27316 -8.79953,1.28077 -18.94747,2.23914 -18.41374,1.73897 -24.77103,3.63832 -17.52829,5.23687 6.36387,1.40458 7.68017,2.15364 4.92039,2.80004 -5.63685,1.32029 -8.1771,4.17319 -8.1771,9.18351 0,2.67093 0.29332,4.85624 0.6518,4.85624 0.35849,0 2.80313,-1.42367 5.43252,-3.16372 l 4.78071,-3.16373 25.50499,1.45199 c 16.94216,0.96451 32.21961,1.08243 45.50498,0.35122 22.01008,-1.21139 35.625,-0.93754 35.625,0.71659 0,0.59017 -2.76306,1.45308 -6.14013,1.91754 -5.1588,0.70951 -6.26427,1.33902 -6.91676,3.9388 -0.48393,1.92812 -1.58532,3.01311 -2.92237,2.87886 -6.87687,7.39882 -8.08734,19.25481 -21.52074,24.05974 0,0.64965 -1.16531,0.81132 -2.58957,0.35927 -2.81815,-0.89445 -7.4104,2.32698 -7.4104,5.19837 0,0.91158 -1.40625,2.01038 -3.125,2.44177 -4.92189,1.23531 -4.0112,5.02957 1.5625,6.50994 4.45924,1.18435 4.28014,1.25127 -3.67801,1.37417 l -8.3655,0.12919 -12.90721,-15.3125 c -7.09896,-8.42187 -15.06928,-18.0152 -17.71182,-21.31851 -2.64254,-3.3033 -5.08145,-5.72918 -5.4198,-5.39083 -0.58414,0.58415 21.71753,32.44192 27.95273,39.93025 l 2.94211,3.5334 0,49.12604 c 0,41.48585 0.28309,49.36097 1.82025,50.63671 3.98569,3.30783 4.42975,0.12935 4.42975,-31.70708 0,-40.98735 1.09557,-61.99748 3.23286,-61.99748 2.09115,0 3.1894,3.65969 2.88039,9.59824 -0.13671,2.62722 0.72916,7.58926 1.92417,11.02676 1.72403,4.95927 1.9845,8.1861 1.26124,15.625 -1.28992,13.26739 -1.36932,35.11822 -0.13039,35.8837 0.57381,0.35452 0.86424,4.51994 0.64543,9.25646 l -0.39785,8.61189 4.52986,2.42786 c 2.49142,1.33533 4.96248,2.03799 5.49124,1.56148 0.52875,-0.47652 0.5881,0.17025 0.13187,1.43724 -1.85913,5.16311 -2.27413,8.32137 -1.09344,8.32137 0.68552,0 1.60513,1.91223 2.04358,4.2494 0.43846,2.33716 1.62606,4.93729 2.63911,5.77805 1.01307,0.84076 1.84193,2.28375 1.84193,3.20662 0,0.92289 1.16273,2.30024 2.58383,3.06079 2.02806,1.08539 3.28389,0.9241 5.83863,-0.74982 2.66318,-1.74498 5.03373,-1.99545 13.04118,-1.37797 6.62505,0.51089 9.78636,0.31975 9.78636,-0.59171 0,-0.82809 1.25956,-1.03025 3.27199,-0.52516 2.21586,0.55614 4.00925,0.15401 5.55607,-1.24584 1.74143,-1.57597 3.71107,-1.89554 8.2905,-1.3451 7.22592,0.86855 6.91243,0.86838 14.92057,0.009 5.60503,-0.60196 6.65476,-0.34531 8.32173,2.03464 1.83235,2.61604 2.44748,2.6885 15.59005,1.8367 11.73494,-0.76058 14.1414,-0.58608 16.90694,1.22597 6.61261,4.33277 12.00203,-3.35886 12.35227,-17.62881 0.12606,-5.13535 0.38443,-6.56032 0.64569,-3.56109 0.96433,11.07034 2.37194,13.07582 5.08194,7.2405 1.04205,-2.24378 1.14618,-3.78157 0.3125,-4.61525 -3.26806,-3.26806 0.77242,-9.50025 6.15926,-9.50025 1.56071,0 4.74624,0.90568 7.07895,2.01263 7.53542,3.57579 7.99718,2.62966 8.13147,-16.6609 0.41953,-60.26895 1.09005,-81.92968 2.59736,-83.90854 0.86646,-1.1375 5.28137,-6.56818 9.81092,-12.06819 11.82506,-14.35897 27.47179,-35.29162 27.47179,-36.753 0,-0.68651 0.9578,-1.78421 2.12845,-2.43933 1.77124,-0.99124 1.85719,-1.518 0.51213,-3.13872 -0.88899,-1.07116 -2.69054,-2.2885 -4.00347,-2.7052 -4.00857,-1.27227 -2.6622,-3.08836 2.30039,-3.10293 7.71421,-0.0226 14.0625,-1.45615 14.0625,-3.17548 0,-1.91918 -4.19159,-2.76627 -14.375,-2.90509 -17.68496,-0.24106 -29.5658,-2.93255 -19.91351,-4.51121 8.7528,-1.43155 10.09931,-2.45596 10.96997,-8.34581 0.44095,-2.983 1.32435,-9.0799 1.96309,-13.54865 0.63875,-4.46875 1.34565,-16.53718 1.5709,-26.81873 l 0.40955,-18.69373 -5.49404,-1.59198 c -3.02171,-0.87557 -5.64694,-1.74465 -5.83382,-1.93126 -0.18688,-0.18661 11.18038,-0.25754 25.26058,-0.15761 23.34367,0.16566 25.75518,0.38605 27.35657,2.5 2.4359,3.21556 2.45818,20.82631 0.0311,24.54978 -1.91035,2.93069 -1.3485,13.39353 0.71923,13.39353 0.59697,0 1.08541,6.76392 1.08541,15.03094 0,14.7208 -0.062,15.0545 -3.00358,16.1729 -3.98745,1.51602 -4.839,3.14085 -3.89606,7.43401 0.59094,2.69049 1.69804,3.75933 4.46763,4.31325 3.65167,0.73034 3.68201,0.8079 3.68201,9.41339 0,7.95612 0.27647,8.87839 3.32785,11.10116 5.57275,4.05946 3.2437,6.53435 -6.14931,6.53435 -5.32515,0 -9.43579,0.78303 -12.61222,2.40246 -2.59175,1.32135 -7.07006,2.75702 -9.9518,3.19038 -22.24026,3.3445 -26.86421,8.56557 -11.99498,13.54397 4.11346,1.37723 9.01395,2.06619 12.53027,1.76163 l 5.7748,-0.50019 2.6808,8.23838 c 1.47445,4.5311 2.67266,10.34775 2.6627,12.92587 -0.01,2.57813 0.4815,4.6875 1.09214,4.6875 0.61064,0 3.80366,-2.65531 7.0956,-5.90069 l 5.98536,-5.90067 1.13166,3.39499 c 0.97602,2.92805 0.5055,4.12648 -3.42086,8.71318 -2.50389,2.925 -6.33945,8.94773 -8.52347,13.38382 -3.45675,7.0212 -3.97307,9.36822 -3.98725,18.125 -0.0135,8.33493 0.56139,11.29206 3.35357,17.25017 4.49457,9.59079 14.82321,20.3007 24.08963,24.97886 10.50297,5.30244 24.90498,6.24433 35.29852,2.30853 9.2816,-3.51476 15.5341,-8.38585 12.9032,-10.05244 -1.0114,-0.64065 -1.488,-1.51562 -1.0592,-1.94439 0.4287,-0.42877 1.9407,-0.0544 3.36,0.83193 2.2093,1.37977 3.0806,1.23865 6.0592,-0.98145 1.9133,-1.42613 5.5852,-5.62696 8.1596,-9.33519 4.1885,-6.03297 7.1942,-8.89334 7.1942,-6.84629 0,0.98772 -3.7323,7.7228 -7.6748,13.84964 -18.1062,28.13786 -58.78209,32.17569 -83.20734,8.25986 l -6.50711,-6.3714 -0.69605,4.68077 c -0.38282,2.57442 -1.56092,7.36688 -2.61801,10.64991 -4.57007,14.19337 -3.5803,23.05395 2.36263,21.15061 1.49362,-0.47836 43.11078,-0.5885 92.48258,-0.24475 49.3718,0.34375 90.9968,0.17088 92.5,-0.38417 3.9952,-1.47522 9.608,-7.22924 9.608,-9.84969 0,-1.24638 -0.5272,-2.26614 -1.1716,-2.26614 -1.5318,0 -8.5844,-14.46241 -9.6007,-19.6875 -0.5143,-2.64418 -0.2992,-4.0625 0.6161,-4.0625 0.7734,0 1.4062,1.1039 1.4062,2.45311 0,4.73999 5.0678,15.92602 9.6297,21.2556 7.937,9.27263 25.6548,18.78919 34.9841,18.79067 5.1282,8e-4 6.1267,1.71339 2.8038,4.80911 -3.1114,2.8987 -7.1272,4.17255 -8.1151,2.57416 -1.3842,-2.23965 -5.5525,-1.21317 -5.5525,1.36735 0,3.09809 -0.8503,3.11549 -5.766,0.118 -5.3893,-3.2863 -20.0772,-4.0749 -22.1858,-1.19117 -1.1516,1.57496 -3.6436,2.04919 -10.8344,2.06187 -5.1363,0.009 -9.9013,0.16381 -10.5888,0.34393 -0.6875,0.18012 -2.823,-0.11363 -4.7457,-0.65268 -4.1879,-1.17424 -5.5696,-0.19411 -3.4043,2.41486 1.3061,1.57378 1.2284,1.90519 -0.4469,1.90519 -1.1154,0 -2.0281,-0.5625 -2.0281,-1.25 0,-2.11781 -4.8029,-1.38022 -6.0995,0.93671 -0.885,1.58135 -0.6755,2.79253 0.7566,4.375 1.0999,1.2153 1.3713,2.18829 0.6104,2.18829 -0.7534,0 -1.7176,-0.5625 -2.1425,-1.25 -0.4249,-0.6875 -1.7954,-1.25 -3.0457,-1.25 -2.5381,0 -5.8883,3.35765 -4.6178,4.6281 0.4497,0.44972 21.7642,0.95014 47.3656,1.11204 35.9467,0.22732 48.4663,-0.1035 54.9712,-1.45272 8.2271,-1.70636 20.4308,-7.2973 25.0469,-11.47478 1.9233,-1.74062 2.4855,-1.80014 3.377,-0.3576 1.1854,1.91797 -1.9031,10.70661 -7.1708,20.40546 -3.5844,6.59939 -12.8979,15.8895 -15.9296,15.8895 -1.0638,0 -5.717,-1.90396 -10.3405,-4.23103 -9.8049,-4.93494 -22.8009,-8.90852 -33.4063,-10.21407 -4.125,-0.5078 -19.1368,-0.80186 -33.3597,-0.65348 -15.0655,0.15718 -26.8155,-0.24171 -28.1494,-0.95562 -1.2594,-0.67399 -5.8146,-1.53905 -10.1228,-1.92239 -6.762,-0.60167 -8.1212,-0.36037 -9.9408,1.76482 -2.7049,3.15909 -6.7984,3.14293 -9.6773,-0.0383 -2.8885,-3.1918 -6.1962,-3.1788 -9.412,0.037 -2.8329,2.83293 -16.2137,5.05725 -32.4478,5.39391 l -9.3599,0.19409 -2.2011,-4.66328 c -2.5625,-5.42903 -6.81604,-7.05629 -12.79411,-4.89459 -2.59769,0.93934 -15.19867,1.43287 -36.58406,1.43287 -17.94184,0 -33.51128,0.34143 -34.59875,0.75874 -1.08749,0.4173 -1.97724,2.1048 -1.97724,3.75 0,1.68451 -0.74054,2.99126 -1.69514,2.99126 -1.32942,0 -1.4792,-1.28098 -0.6942,-5.9375 1.66629,-9.88424 3.76994,-34.08991 3.06218,-35.23508 -0.36466,-0.59005 -3.45561,-2.07702 -6.86877,-3.30437 -5.80342,-2.08687 -6.04685,-2.34283 -3.75491,-3.94817 2.25957,-1.58264 2.45084,-3.26642 2.45084,-21.57485 0,-19.10392 -0.1055,-19.93215 -2.77814,-21.80412 -1.52796,-1.07023 -3.91858,-1.94662 -5.3125,-1.94752 -2.46303,-10e-4 -2.52336,0.60529 -2.14359,21.5625 0.21494,11.86028 0.91807,22.09851 1.5625,22.75164 2.20224,2.23189 1.17237,3.1875 -3.43521,3.1875 -2.82656,0 -5.6042,0.93234 -7.1875,2.41255 -1.97714,1.84841 -3.54543,2.21369 -6.7069,1.56211 -2.26947,-0.46774 -4.02008,-1.41276 -3.89025,-2.10005 0.69341,-3.67024 -18.73656,-6.35559 -20.88095,-2.88589 -0.50605,0.8188 -0.258,1.70943 0.55123,1.97918 2.83802,0.946 1.43518,2.7821 -2.12564,2.7821 -4.93174,0 -6.19889,2.0042 -6.64514,10.51041 l -0.38291,7.29895 -47.5,0.29293 c -26.125,0.1611 -51.62871,0.73982 -56.67491,1.28603 -9.98793,1.08113 -12.48712,3.1494 -7.7851,6.44283 2.57031,1.80031 2.61276,2.06634 0.67187,4.21099 -1.13946,1.2591 -2.79006,2.01362 -3.668,1.67672 -1.74544,-0.66979 -3.60316,2.81715 -2.47415,4.64394 0.38656,0.62546 1.51339,1.1372 2.50406,1.1372 0.99068,0 1.80123,1.16197 1.80123,2.58217 0,1.4202 0.5894,3.68348 1.30977,5.02952 0.99933,1.86726 0.83797,2.91915 -0.68079,4.43791 -2.96038,2.96036 -1.65063,4.77627 3.77049,5.22769 2.65718,0.22125 5.42619,1.14463 6.15338,2.05195 1.4336,1.78872 51.5889,4.3785 87.57215,4.5218 20.83756,0.083 29.06969,1.58233 15.625,2.84586 -4.46875,0.41996 -23.52999,1.09686 -42.35831,1.50422 -18.82833,0.40735 -35.45055,1.20343 -36.93828,1.76907 -1.48772,0.56562 -4.22335,0.73816 -6.07917,0.3834 -2.66209,-0.50889 -3.40365,-0.15259 -3.51362,1.68818 -0.71875,12.03232 -1.82743,15.05339 -5.89945,16.0754 -5.17137,1.29793 -6.73997,3.0326 -4.64061,5.13197 0.96298,0.96297 2.80355,1.75086 4.09015,1.75086 1.28662,0 2.99045,0.65116 3.78631,1.44702 1.09603,1.09603 1.97144,1.02023 3.60904,-0.3125 1.90541,-1.5507 2.06776,-1.50783 1.36786,0.36112 -1.00388,2.68071 1.87397,3.09826 32.82608,4.76281 33.16542,1.78359 52.0333,3.57146 60.625,5.74469 4.86816,1.23137 11.66706,1.76106 19.375,1.50947 l 11.875,-0.38761 1.00912,-6.875 c 1.18743,-8.08978 3.15553,-16.0015 4.7377,-19.04554 0.6205,-1.1938 1.12818,-3.17049 1.12818,-4.39265 0,-2.87739 4.5677,-15.37951 6.22416,-17.03597 1.63709,-1.63709 1.6339,1.99897 -0.018,20.47416 -2.2812,25.51385 -4.51285,32.9434 -10.19246,33.93247 -1.58879,0.27669 -6.54496,0.11088 -11.01371,-0.36848 z M 716.69536,704.10214 c 4.13963,-1.18883 4.62306,-1.80257 5.37631,-6.82566 0.54862,-3.65844 0.28333,-6.39102 -0.78682,-8.1046 -1.32213,-2.11707 -1.31678,-3.06192 0.0296,-5.2178 1.43117,-2.29167 1.30824,-2.94545 -0.94933,-5.04869 -1.42639,-1.32886 -2.59342,-2.9248 -2.59342,-3.54653 0,-2.01403 5.4555,-5.01893 9.34064,-5.14484 2.0814,-0.0675 -1.55939,-0.92663 -8.09064,-1.90926 -15.49891,-2.33184 -16.80037,-2.90899 -10.625,-4.71184 6.1462,-1.79432 8.70719,-6.26955 8.73224,-15.25919 0.0159,-5.69442 0.2461,-6.23532 2.14841,-5.04731 1.17186,0.73184 2.50697,0.95429 2.96692,0.49434 1.55105,-1.55105 -0.62345,-4.69409 -3.24757,-4.69409 -2.31594,0 -2.59601,-0.72478 -2.53593,-6.5625 0.13583,-13.19694 -0.92461,-24.73769 -2.44092,-26.56474 -0.85485,-1.03001 -3.36039,-1.87276 -5.56788,-1.87276 -5.66665,0 -6.473,-1.49252 -1.6488,-3.05185 2.25144,-0.72774 3.96283,-1.88565 3.80309,-2.57315 -0.41618,-1.79121 -9.76659,-2.26694 -12.7868,-0.65056 -3.07765,1.64711 -3.33947,3.77556 -0.46442,3.77556 4.6709,0 0.0244,1.62259 -6.72254,2.34753 l -7.2358,0.77747 -0.63865,5 c -0.35125,2.75 -0.07,15.35865 0.625,28.01923 l 1.26365,23.01922 5,2.11239 5,2.11239 -5.35935,0.92367 c -4.20979,0.72555 -5.21834,1.36796 -4.70194,2.99501 0.36159,1.13924 0.90461,7.1331 1.20674,13.31972 0.30213,6.1866 1.15238,12.79525 1.88944,14.68587 0.73706,1.89063 1.91999,4.92608 2.62872,6.74544 1.28535,3.29956 1.31463,3.30599 11.5625,2.53589 5.65064,-0.42464 12.32078,-1.3599 14.82252,-2.07835 z m 33.57637,-5.5667 c 0,-0.30317 -0.5625,-0.89887 -1.25,-1.32377 -0.6875,-0.4249 -1.25,-0.17685 -1.25,0.55123 0,0.72807 0.5625,1.32377 1.25,1.32377 0.6875,0 1.25,-0.24805 1.25,-0.55123 z m 330.98727,-68.0843 c 5.2488,-2.69981 12.3733,-9.67061 11.1421,-10.90173 -0.4473,-0.44734 -3.0446,1.20247 -5.7717,3.66625 -2.7271,2.46377 -6.6794,5.3696 -8.783,6.4574 -2.1036,1.0878 -3.8247,2.24461 -3.8247,2.57071 0,1.20385 2.7232,0.52934 7.2373,-1.79263 z m -18.3576,-3.93385 c 1.7333,-0.92763 1.9805,-1.93137 1.171,-4.75403 -3.3917,-11.82599 -9.1432,-13.9841 -31.6132,-11.86195 -10.0702,0.95107 -10.5,2.12282 -3.3876,9.23527 4.9678,4.96775 8.1482,6.76256 15.5751,8.78946 4.2799,1.16804 14.9833,0.34203 18.2547,-1.40875 z m -90.84622,-6.37267 c 1.0816,-2.16813 1.96655,-5.54313 1.96655,-7.5 0,-2.91295 -0.53876,-3.55795 -2.97195,-3.55795 -4.2524,0 -6.33473,2.8742 -4.52805,6.25 1.06805,1.99566 1.06284,3.09436 -0.0209,4.40015 -0.79438,0.95719 -1.08147,2.32748 -0.63796,3.0451 1.51878,2.45743 4.22588,1.30448 6.19229,-2.6373 z m -362.06991,1.20768 c -0.77259,-2.31778 -3.46354,-2.70221 -3.46354,-0.49479 0,1.08854 0.89062,1.97916 1.97917,1.97916 1.08854,0 1.75651,-0.66798 1.48437,-1.48437 z m 520.53643,-6.26563 c -0.7047,-0.70469 -1.9683,-1.05224 -2.808,-0.77233 -1.0624,0.35414 -0.8275,1.20822 0.7723,2.80804 1.5998,1.59984 2.4539,1.83474 2.8081,0.77233 0.2799,-0.83974 -0.068,-2.10335 -0.7724,-2.80804 z m -522.74997,-2.25 c 0,-2.87866 -0.56375,-3.75 -2.42623,-3.75 -1.33443,0 -2.77698,0.56754 -3.20568,1.26119 -1.36545,2.20932 0.71178,6.23881 3.21614,6.23881 1.85085,0 2.41577,-0.87693 2.41577,-3.75 z m 531.79407,-8.61902 c 1.2008,-1.94291 -2.7906,-2.56755 -4.3557,-0.68168 -1.2189,1.46865 -1.0189,1.8007 1.0848,1.8007 1.4186,0 2.8905,-0.50356 3.2709,-1.11902 z m -539.29407,-5.13098 c 0,-0.6875 -0.84375,-1.25 -1.875,-1.25 -1.03125,0 -1.875,0.5625 -1.875,1.25 0,0.6875 0.84375,1.25 1.875,1.25 1.03125,0 1.875,-0.5625 1.875,-1.25 z m 298.35389,-8.98437 c -0.39903,-0.99717 -0.69523,-0.70098 -0.7552,0.75521 -0.0542,1.3177 0.24116,2.05598 0.65652,1.64062 0.41537,-0.41536 0.45977,-1.4935 0.0986,-2.39583 z m -341.72121,-4.31498 c 1.33102,-1.33101 -0.33719,-2.88965 -2.29053,-2.14008 -1.00529,0.38577 -1.51658,1.20495 -1.1362,1.82041 0.81025,1.31102 2.29672,1.44968 3.42673,0.31967 z m 8.36732,-3.01043 c 0,-0.63922 -1.43756,-1.04324 -3.19458,-0.89782 -2.87108,0.23761 -2.97901,0.42201 -1.06585,1.82095 2.18247,1.59586 4.26043,1.14562 4.26043,-0.92313 z m -23.75,-1.68148 c 0,-0.2702 -0.87296,-0.82625 -1.93992,-1.23569 -1.11241,-0.42686 -1.61415,-0.21731 -1.17623,0.49126 0.73407,1.18776 3.11615,1.75681 3.11615,0.74443 z m -3.75,-10.83252 c 0,-0.64692 -0.8261,-1.17622 -1.83577,-1.17622 -1.1151,0 -1.55439,0.73325 -1.11902,1.86782 0.73786,1.92283 2.95479,1.40394 2.95479,-0.69159 z m 361.61763,-20.23872 c -0.28334,-0.51562 -1.04448,-0.9375 -1.6914,-0.9375 -1.40807,0 -1.52668,7.32543 -0.25523,15.76304 0.92035,6.10759 0.92156,6.1048 1.6914,-3.88804 0.42373,-5.5 0.53857,-10.42187 0.25523,-10.9375 z m -365.02705,-8.52011 c -0.44056,-1.68473 -1.1008,-2.15716 -1.89906,-1.35891 -1.29387,1.29387 -0.27605,3.94152 1.51523,3.94152 0.58256,0 0.75529,-1.16218 0.38383,-2.58261 z m 398.39594,-4.27615 c 4.06649,-4.89983 -2.7219,-11.36018 -8.6201,-8.20355 -2.54677,1.363 -3.69678,7.31527 -1.78308,9.22897 1.55951,1.55953 8.85465,0.84045 10.40318,-1.02542 z m -44.98652,127.51586 c 0,-0.3261 1.6875,-1.46554 3.75,-2.5321 2.41874,-1.25078 3.76947,-2.92625 3.80486,-4.7196 0.0379,-1.91956 0.61258,-1.23235 1.85619,2.2196 0.99071,2.75 1.80978,5.14063 1.82013,5.3125 0.01,0.17188 -2.51243,0.3125 -5.60618,0.3125 -3.09375,0 -5.625,-0.2668 -5.625,-0.5929 z m 8.78829,-11.9071 c 0,-3.48003 2.05889,-5.20581 5.71166,-4.7876 2.21791,0.25394 3.7622,1.24861 4.01592,2.58666 0.34532,1.82099 -0.23177,2.04526 -3.55332,1.38095 -2.73398,-0.5468 -4.30858,-0.25146 -5.06993,0.95094 -0.92343,1.45835 -1.10433,1.4369 -1.10433,-0.13095 z m -143.16329,-25 c -0.4249,-0.6875 0.10438,-1.25 1.17622,-1.25 1.07183,0 1.94878,0.5625 1.94878,1.25 0,0.6875 -0.5293,1.25 -1.17623,1.25 -0.64692,0 -1.52387,-0.5625 -1.94877,-1.25 z m 356.30337,-1.16363 c -0.8538,-1.38153 1.118,-2.87331 2.2723,-1.71906 1.1885,1.18849 0.967,2.88269 -0.3769,2.88269 -0.6469,0 -1.4998,-0.52364 -1.8954,-1.16363 z m 72.1341,-13.46853 c -1.5468,-0.29795 -2.8125,-1.10535 -2.8125,-1.79424 0,-0.68887 1.2657,-1.12862 2.8125,-0.9772 1.5469,0.15143 3.8212,-0.15906 5.0539,-0.68996 2.729,-1.17525 3.9474,-0.17868 2.9523,2.41465 -0.728,1.89706 -2.4336,2.12006 -8.0062,1.04675 z m 12.1875,-6.61784 c 0,-0.6875 0.5957,-1.25 1.3238,-1.25 0.7281,0 0.9761,0.5625 0.5512,1.25 -0.4249,0.6875 -1.0206,1.25 -1.3237,1.25 -0.3032,0 -0.5513,-0.5625 -0.5513,-1.25 z m 16.2898,-12.8125 c 0.074,-2.92494 6.1198,-8.4375 9.2531,-8.4375 2.0842,0 0.212,2.69183 -3.0429,4.375 -2.0625,1.06656 -3.75,2.7685 -3.75,3.7821 0,1.0136 -0.5625,1.8429 -1.25,1.8429 -0.6875,0 -1.2321,-0.70312 -1.2102,-1.5625 z m -362.1652,-10.9375 c 0,-3.78125 0.23434,-5.32812 0.52074,-3.4375 0.28642,1.89063 0.28642,4.98438 0,6.875 -0.2864,1.89063 -0.52074,0.34375 -0.52074,-3.4375 z m -247.87457,-1.02318 c 0,-1.51068 2.3715,-3.27198 3.23837,-2.40512 0.31462,0.31463 -0.2853,1.28358 -1.33316,2.15322 -1.18798,0.98594 -1.90521,1.08078 -1.90521,0.2519 z m -8.75,-3.24766 c 0,-1.08853 0.89062,-1.97916 1.97917,-1.97916 1.08854,0 1.75651,0.66796 1.48437,1.48438 -0.77259,2.31777 -3.46354,2.70219 -3.46354,0.49478 z m -10.58422,-1.91317 c -0.44733,-0.7238 -0.6395,-1.35903 -0.42705,-1.41163 3.3865,-0.83848 4.81808,-0.69981 4.4414,0.43024 -0.65256,1.95769 -3.0489,2.54353 -4.01435,0.98139 z m 267.14944,-8.19099 c 0.0139,-2.75 0.26987,-3.72781 0.56886,-2.17292 0.29898,1.55488 0.28763,3.80488 -0.0253,5 -0.31286,1.19511 -0.55749,-0.0771 -0.54362,-2.82708 z m 277.18475,-11.02312 c 0,-5.08018 3.8951,-16.23728 7.4956,-21.47039 8.0448,-11.69278 20.5005,-19.93213 32.5005,-21.49879 6.1541,-0.80346 6.6856,0.25254 0.6289,1.24979 -9.7,1.59716 -17.6139,7.14435 -26.3038,18.4375 -6.2746,8.15431 -11.7903,19.06871 -11.809,23.36751 -0.01,1.54688 -0.5747,2.8125 -1.2622,2.8125 -0.6875,0 -1.25,-1.30415 -1.25,-2.89812 z m -277.30261,-4.60188 c 0,-1.71875 0.28373,-2.42187 0.63049,-1.5625 0.34676,0.85938 0.34676,2.26563 0,3.125 -0.34676,0.85938 -0.63049,0.15625 -0.63049,-1.5625 z m 370.70011,-4.91426 c -4.1673,-11.73332 -12.7765,-20.27788 -30.2725,-30.04528 l -5,-2.79132 4.251,0.75689 c 11.2177,1.99726 25.9006,14.35396 31.3995,26.42484 1.5438,3.38885 3.6618,6.78668 4.7067,7.55072 1.0449,0.76403 1.4994,2.03698 1.01,2.82879 -1.8149,2.93661 -3.9659,1.26916 -6.0947,-4.72464 z m -223.55692,-5.91539 c -1.5556,-1.88575 -1.45333,-1.93993 1.09695,-0.58102 2.9087,1.54988 3.62491,2.66067 1.71555,2.66067 -0.60331,0 -1.86894,-0.93584 -2.8125,-2.07965 z m 84.81512,-2.4313 c -1.1962,-1.19626 -1.1699,-6.75055 0.032,-6.69824 1.6703,0.0728 14.0868,4.56686 14.9204,5.40043 0.4448,0.44481 -1.3944,0.81643 -4.0871,0.82582 -2.6927,0.01 -6.0351,0.32322 -7.4276,0.69739 -1.3925,0.37417 -2.9393,0.27274 -3.4375,-0.2254 z m -13.0134,-8.27159 c -3.9197,-4.28549 -6.721,-10.51222 -7.7999,-17.33786 -0.7576,-4.79224 -0.6006,-6.1296 0.7193,-6.1296 0.9286,0 1.6883,-0.95625 1.6883,-2.125 0,-3.26799 1.8522,-0.42853 3.8323,5.875 0.9718,3.09375 3.6008,8.3534 5.8423,11.68811 4.665,6.94028 4.704,7.06189 2.2625,7.06189 -0.997,0 -2.2926,0.85724 -2.8789,1.90496 -0.9091,1.62453 -1.4488,1.4865 -3.6659,-0.9375 z m -453.48853,-6.25066 c -3.73484,-3.21259 -3.47276,-5.9668 0.5678,-5.9668 5.9514,0 7.7076,2.56771 4.63251,6.77315 -1.56245,2.13677 -1.82629,2.09586 -5.20031,-0.80635 z m 10.96866,-0.242 c -3.84481,-3.30718 -3.2323,-6.99714 1.15087,-6.93321 2.89233,0.0421 8.48483,3.8624 8.46698,5.78377 -0.005,0.5773 -1.43109,1.70903 -3.16828,2.51495 -2.71685,1.26041 -3.61873,1.06946 -6.44957,-1.36551 z m 352.29296,-1.57136 -6.70964,-4.41473 2.66544,-2.66542 2.66543,-2.66544 3.10671,3.6155 c 1.70869,1.98853 3.1067,4.18684 3.1067,4.88515 0,0.6983 0.93093,2.29831 2.06874,3.55557 3.13123,3.45998 0.55795,2.59868 -6.90338,-2.31063 z m -128.91536,-2.27844 c 0,-1.03125 0.54485,-1.875 1.21077,-1.875 0.66592,0 0.88699,0.84375 0.49127,1.875 -0.39574,1.03125 -0.94058,1.875 -1.21078,1.875 -0.27019,0 -0.49126,-0.84375 -0.49126,-1.875 z m -123.05529,-0.5122 c -0.9983,-1.61529 0.59301,-5.23703 1.93626,-4.40685 1.48848,0.91992 1.44075,5.54405 -0.0572,5.54405 -0.64693,0 -1.4925,-0.51174 -1.87906,-1.1372 z m 455.32096,-5.96669 c 0.9023,-0.36108 1.9804,-0.31668 2.3958,0.0986 0.4154,0.41536 -0.3229,0.7108 -1.6406,0.65652 -1.4562,-0.06 -1.7524,-0.35617 -0.7552,-0.7552 z m -547.02198,-4.77111 c 0.0255,-2.0625 0.30562,-2.75492 0.62255,-1.53871 0.31692,1.21621 0.29608,2.90371 -0.0462,3.75 -0.34241,0.84628 -0.60172,-0.14879 -0.57624,-2.21129 z m 103.8426,-0.24124 c 1.21621,-0.31692 2.90371,-0.29608 3.75,0.0464 0.84628,0.34241 -0.14879,0.60171 -2.21129,0.57623 -2.0625,-0.0255 -2.75493,-0.30562 -1.53871,-0.62254 z m 230.60351,-1.94626 c -0.47374,-1.20312 -1.86336,-2.2046 -3.08808,-2.22551 -2.08745,-0.0356 -2.08236,-0.12188 0.0812,-1.37953 2.81819,-1.6381 5.00959,0.11725 4.33483,3.47226 -0.43408,2.15824 -0.52681,2.16752 -1.328,0.13278 z m 191.52897,-10 c -6.5896,-4.46474 -7.8624,-11.82811 -3.0791,-17.8125 1.9626,-2.45539 1.9747,-2.45127 0.6793,0.23033 -3.2824,6.79483 0.7064,16.64467 6.7405,16.64467 5.6342,0 10.9886,1.5417 9.2289,2.65728 -3.043,1.92903 -9.3673,1.12749 -13.5696,-1.71978 z m 6.7289,-43.125 c 0.4262,-2.57812 0.8371,-7.78125 0.9132,-11.5625 0.1073,-5.33632 0.3623,-6.1756 1.1391,-3.75 1.2206,3.81111 1.5339,15.30583 0.4913,18.02276 -1.5121,3.94056 -3.3238,2.01016 -2.5436,-2.71026 z m -146.3929,1.875 c 0.2821,-0.85937 2.0131,-1.74015 3.8465,-1.95729 2.5958,-0.30743 3.1672,0.0382 2.5823,1.5625 -0.8987,2.34196 -7.1952,2.72863 -6.4288,0.39479 z m 58.0286,0.72916 c -0.4584,-0.45832 -0.785,-4.2552 -0.7259,-8.4375 0.1136,-8.04469 1.1645,-6.57565 2.8314,3.95834 0.7726,4.88204 -0.019,6.56577 -2.1055,4.47916 z m -54.5663,-17.97916 c 0.025,-4.57298 1.374,-8.74784 2.5841,-7.99998 1.2281,0.75903 0.1,8.10533 -1.5165,9.87498 -0.6406,0.70135 -1.0777,-0.0663 -1.0676,-1.875 z m 91.0909,-0.39377 c -1.6406,-1.62594 -4.3892,-3.37873 -6.108,-3.89508 -3.0703,-0.9224 -9.5222,-5.28736 -14.2982,-9.67332 -4.5206,-4.15147 -7.6243,-2.36499 -12.2056,7.02544 l -3.7196,7.62423 0.6141,-5.28491 c 0.3377,-2.90672 2.2623,-7.96922 4.2769,-11.25 3.1591,-5.14481 4.341,-6.05752 8.5949,-6.63724 2.7127,-0.36968 6.3073,-1.6353 7.988,-2.8125 1.6807,-1.17719 3.6661,-2.14035 4.4121,-2.14035 1.355,0 5.5874,8.33311 5.5874,11.00105 0,0.77604 1.08,1.98896 2.3999,2.69537 1.32,0.70642 3.0754,3.39808 3.901,5.98148 0.8256,2.58341 1.9957,5.23147 2.6001,5.8846 1.4114,1.52504 1.4242,4.4375 0.019,4.4375 -0.5937,0 -2.4218,-1.33033 -4.0625,-2.95627 z m 50.142,-9.26921 c 0,-0.76567 -2.7619,-5.0411 -6.1375,-9.50093 -3.3757,-4.45985 -5.3739,-7.81578 -4.4405,-7.45762 3.4013,1.30524 12.8589,16.06984 11.2952,17.63353 -0.3944,0.39444 -0.7172,0.0907 -0.7172,-0.67498 z m -138.6513,-6.00368 c 0.06,-1.45619 0.3562,-1.75238 0.7552,-0.75522 0.3611,0.90234 0.3167,1.98047 -0.099,2.39584 -0.4154,0.41536 -0.7108,-0.32292 -0.6565,-1.64062 z m -281.59432,-1.94989 c -5.29136,-0.60613 -10.91636,-1.59095 -12.5,-2.18849 -2.38884,-0.90136 -1.65211,-1.24301 4.32468,-2.00554 3.96219,-0.50551 7.59337,-1.54911 8.06926,-2.31911 0.71932,-1.1639 1.18164,-7.85029 1.54671,-22.37031 24.6942,-15.87749 -2.90366,-17.93893 -1.61461,-32.57265 0.77603,-8.31038 0.78108,-8.31939 5.12613,-9.13451 4.10627,-0.77034 26.54247,0.35197 27.56958,1.3791 0.26305,0.26304 0.39611,1.7804 0.29571,3.37191 -0.10037,1.59151 -0.29825,5.55171 -0.43967,8.80046 -14.65784,13.54355 0.29782,19.95636 0.49935,30.03069 0.103,7.87279 0.803,15.34169 1.68288,17.95771 0.90943,2.70385 7.63079,5.47979 13.26815,5.47979 1.9962,0 2.51208,0.4054 1.63368,1.2838 -1.39516,1.39516 -23.51041,3.70642 -33.5912,3.51061 -3.4375,-0.0668 -10.57929,-0.61732 -15.87065,-1.22346 z m 72.43315,-0.71626 c -1.89063,-0.28642 -3.4375,-1.04588 -3.4375,-1.68772 0,-1.47181 22.11483,-1.55147 23.02244,-0.0829 1.19037,1.92609 -11.1776,3.04425 -19.58494,1.77065 z m -192.5751,-88.79219 c 0.81049,-18.36271 1.42061,-18.85829 1.53891,-1.25 0.0543,8.07813 -0.40322,14.6875 -1.01666,14.6875 -0.62141,0 -0.85269,-5.95087 -0.52225,-13.4375 z m 328.55996,3.49296 c 0.026,-5.46802 0.44794,-10.34242 0.9375,-10.832 0.48958,-0.48957 0.89014,3.98487 0.89014,9.9432 0,5.95834 -0.42188,10.83274 -0.9375,10.832 -0.51563,-7.2e-4 -0.91619,-4.47517 -0.89014,-9.9432 z M 682.79087,320.02417 c 0.0112,-3.18657 0.42336,-4.67559 1.02925,-3.72092 0.95065,1.49791 0.47912,9.03342 -0.56526,9.03342 -0.26572,0 -0.47452,-2.39062 -0.46399,-5.3125 z m -0.33743,-27.5 c -0.32216,-0.85937 -0.14062,-2.6875 0.40341,-4.0625 0.8055,-2.03582 1.00548,-1.74571 1.07702,1.5625 0.0914,4.22468 -0.4752,5.18144 -1.48043,2.5 z m -58.18802,-9.0625 c 0.0255,-2.0625 0.30562,-2.75492 0.62255,-1.53871 0.31692,1.21621 0.29608,2.90371 -0.0462,3.75 -0.34248,0.84629 -0.60178,-0.14879 -0.5763,-2.21129 z m 325.80761,-24.45616 c -3.02672,-1.70142 -23.169,-3.59822 -40.4263,-3.80694 l -15,-0.18143 8.75,-1.18784 c 4.8125,-0.65332 9.11801,-1.5658 9.5678,-2.02774 0.44979,-0.46194 1.41377,-6.44429 2.14219,-13.29412 1.02117,-9.60281 0.97704,-12.67497 -0.19279,-13.41836 -2.32552,-1.4778 33.92211,-1.18974 36.68998,0.29157 2.18752,1.17073 2.40946,2.68877 2.32996,15.9375 -0.0991,16.52052 -0.73711,19.44331 -3.86084,17.68736 z m -326.17456,-2.64916 c -0.6197,-1.15793 -1.12674,-7.97968 -1.12674,-15.15945 0,-10.36748 0.4061,-13.39115 1.97321,-14.69174 1.42299,-1.18097 7.95839,-1.72262 23.4375,-1.94246 11.80535,-0.16766 20.17419,-0.0198 18.59741,0.32863 -1.98686,0.43902 -2.66404,1.27607 -2.2061,2.7269 0.36343,1.15139 0.72688,4.90594 0.80767,8.34344 0.24705,10.51193 2.00528,15.46695 5.87261,16.54993 4.88566,1.36815 66.21728,1.01301 72.04232,-0.41716 4.15866,-1.02104 4.96781,-1.76476 5.3505,-4.91787 0.24799,-2.04319 0.97437,-5.28282 1.61417,-7.19917 0.69446,-2.08009 0.71217,-4.67075 0.0439,-6.42835 -0.61564,-1.61924 -0.80936,-4.12945 -0.43048,-5.57823 0.62986,-2.4086 1.55935,-2.63251 10.85555,-2.61501 5.80756,0.0109 9.47139,0.46021 8.54504,1.04784 -1.29527,0.82165 -1.23237,1.35179 0.3125,2.63391 1.06385,0.88287 1.93423,3.5051 1.93423,5.82717 0,2.32206 0.46507,4.22194 1.03351,4.22194 0.56843,0 0.84186,1.54687 0.60763,3.4375 -0.66102,5.33538 2.34985,7.96332 11.11715,9.70328 6.43696,1.27747 7.07157,1.60033 3.49171,1.7764 -37.25432,1.83233 -100.60586,3.87928 -127.93576,4.13373 -31.55846,0.29381 -34.91604,0.12739 -35.9375,-1.78123 z m 204.20295,-1.91666 c 1.90007,-0.28732 4.71257,-0.27964 6.25,0.0171 1.53742,0.2967 -0.0172,0.53178 -3.45469,0.52239 -3.4375,-0.009 -4.69539,-0.25214 -2.79531,-0.53946 z"
-               style="fill:#101010" />
+               id="path4200"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="csssscscssssssssssssscssscsssssssssscsscscsscsssssssscssssccssssscccsssssssssssssssscscsssssssssssscsssssccssssscsssscssssssscscscsssssssssssscssssssssssscssssssssssscssssssssssssssssscscsscssssssscccccssscssssssssssssscssscsccssccssscsscccsssscssssscssscssscsssscscssscsssscssssssssssssssssssssssssssscsssssscccssssscsssssssssssssscsscccscssssccsssssccssscscsssscssscscccssccssccsssssccscsssssccsccssssssssscsssssssssssssssssssssscscsssscssssssssccsccsscccssssscsssscsscsscsssssssssscscccssssscsssssssscssscsssssccccsccscssssssssssssccssscccsssssscssssssccccccscccccscccccsccsssscsccccccscccsccccccccsscccsssscscsccssccscccccssssccsccccssssscssccssssscscscsscsssscscccsscssssssscssscssssssccsscssssssccccccc" />
           </g>
         </g>
       </g>
     </g>
     <g
-       transform="translate(82.045711,73.355541)"
+       inkscape:label="Layer 1"
        id="layer1-43"
-       inkscape:label="Layer 1">
+       transform="translate(82.045711,73.355541)">
       <g
-         transform="matrix(0.70710678,-0.70710678,0.70710678,0.70710678,-216.8875,351.66629)"
-         id="g4271">
+         id="g4271"
+         transform="matrix(0.70710678,-0.70710678,0.70710678,0.70710678,-216.8875,351.66629)">
         <rect
-           style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999785;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="rect4145-0"
-           width="205.65259"
-           height="4.806571"
-           x="-187.93834"
+           transform="matrix(0.70600487,-0.70820697,0.70600487,0.70820697,0,0)"
            y="530.37567"
-           transform="matrix(0.70600487,-0.70820697,0.70600487,0.70820697,0,0)" />
+           x="-187.93834"
+           height="4.806571"
+           width="205.65259"
+           id="rect4145-0"
+           style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999785;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 390.34762,366.47444 -2.21123,24.43028"
+           inkscape:connector-curvature="0"
            id="path4293-9"
-           inkscape:connector-curvature="0" />
+           d="m 390.34762,366.47444 -2.21123,24.43028"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
         <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="M 388.13639,390.90472 267.37357,512.5646"
+           inkscape:connector-curvature="0"
            id="path4295-2"
-           inkscape:connector-curvature="0" />
+           d="M 388.13639,390.90472 267.37357,512.5646"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
         <path
-           style="fill:url(#radialGradient4190);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           d="m 255.13747,511.67922 c -4.83857,-0.10225 -7.7582,-0.27692 -7.76954,-0.46482 -0.033,-0.54705 141.93887,-142.76892 142.00797,-142.258 0.0361,0.26699 -0.37024,5.23929 -0.90301,11.04957 l -0.96867,10.56413 -60.20067,60.62316 -60.20067,60.62315 -2.10702,0.0133 c -1.15886,0.007 -5.59514,-0.0604 -9.85839,-0.1505 l 0,10e-6 z"
+           inkscape:connector-curvature="0"
            id="path4170-5"
-           inkscape:connector-curvature="0" />
+           d="m 255.13747,511.67922 c -4.83857,-0.10225 -7.7582,-0.27692 -7.76954,-0.46482 -0.033,-0.54705 141.93887,-142.76892 142.00797,-142.258 0.0361,0.26699 -0.37024,5.23929 -0.90301,11.04957 l -0.96867,10.56413 -60.20067,60.62316 -60.20067,60.62315 -2.10702,0.0133 c -1.15886,0.007 -5.59514,-0.0604 -9.85839,-0.1505 l 0,10e-6 z"
+           style="fill:url(#radialGradient4190);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
         <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 245.15589,512.11904 21.94699,-0.30263"
+           inkscape:connector-curvature="0"
            id="path4269-5"
-           inkscape:connector-curvature="0" />
+           d="m 245.15589,512.11904 21.94699,-0.30263"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
       </g>
     </g>
     <path
-       inkscape:connector-curvature="0"
-       id="path4179"
+       style="fill:#000000"
        d="m 188.89633,791.65504 c 9.60934,-22.25902 21.61568,-43.38856 31.22439,-65.64787 -14.93136,-7.2771 -30.32021,-13.54832 -45.5056,-20.26358 -3.57197,4.84335 -2.0533,-6.17594 -7.11361,-6.45015 -13.14745,-13.23081 -27.06313,-25.70438 -41.7235,-37.23877 -10.26946,1.37321 4.37855,-6.86406 3.26843,-12.27629 3.36951,-6.27159 4.27246,-16.67333 5.08745,-18.59397 25.06001,-9.59711 52.74876,-19.16652 79.66939,-11.93218 8.53501,2.82409 17.22875,7.22851 26.27546,3.60388 9.87614,-2.76985 15.47038,7.70039 23.6315,10.98959 9.48082,5.69436 20.2338,8.66133 30.56779,12.18074 11.64177,5.84225 10.76578,21.60185 21.7675,27.73963 18.44767,16.71272 27.96913,40.20702 37.20516,62.70524 2.45146,3.43266 4.73373,14.3483 -0.17721,5.2072 -11.33689,-15.88191 -25.01541,-29.93806 -38.02471,-44.41934 -3.82311,-4.16783 -19.27653,-15.11272 -11.16542,-3.50166 7.75547,13.85785 12.36228,29.14806 17.41873,44.1602 2.68213,5.14053 1.97609,17.97487 6.21625,18.2557 6.68211,-5.07278 20.65423,-11.55593 24.87964,-11.7831 -8.35423,5.73884 -22.20614,6.51555 -26.25929,16.65684 -6.72957,-4.09323 -20.2847,-7.85964 -30.23738,-10.06806 -12.78682,-2.72752 -25.59581,-5.75947 -38.45857,-7.8462 -11.34473,2.42739 -18.91909,-11.37302 -30.64672,-13.77594 -10.2434,-3.75668 -10.81738,16.0123 -16.49366,22.3602 -6.74263,13.68821 -12.96644,27.63367 -20.10628,41.12459 l -0.68151,-0.52326 -0.61823,-0.66344 0,0 z m 134.81315,-35.18703 c -5.336,-22.85198 -11.20992,-46.12747 -23.1036,-66.51875 -6.80167,-9.4661 -19.70792,-8.53924 -28.72047,-14.8424 -14.53438,-7.60896 -7.26506,14.92728 -10.94891,22.58858 -2.33788,14.83305 -6.13718,29.3888 -8.54485,44.20918 19.3191,1.45266 38.00302,7.1593 56.83944,11.34547 3.67276,-0.56058 14.48003,7.15931 14.47839,3.21792 z m -73.37695,-16.28085 c -6.47182,-2.97495 4.09803,-0.10992 2.06721,-6.80344 2.58378,-18.10983 7.59118,-35.91696 8.34682,-54.26521 -3.28809,-6.63519 -13.64915,-15.48249 -14.9011,-2.43013 -7.92425,16.35171 -15.54409,32.85037 -22.89733,49.46648 9.48732,3.956 17.77355,10.37077 27.3844,14.0323 z m -12.99872,-7.93964 c 1.00476,-1.11074 0.89099,1.85544 0,0 z m -14.41865,-11.40565 c 8.00593,-17.585 16.96071,-34.82504 24.15019,-52.72691 -4.36532,-8.23428 -18.15917,-5.49889 -25.81432,-9.55343 -9.96442,5.12113 -17.44083,14.24312 -25.29458,22.1233 -5.8983,7.80083 -17.57015,17.68995 -18.70178,25.12891 12.54488,5.77345 25.71419,10.05653 37.5508,17.19644 2.87822,1.60042 7.20537,1.8826 8.10969,-2.16831 z m -46.3972,-23.71064 c -3.66531,10.90892 6.29763,-9.19552 4.24571,-2.82186 6.64907,-8.29221 15.00141,-15.12328 22.18475,-23.41016 7.65722,-7.31855 16.05097,-14.22951 25.90741,-18.37397 -3.62514,-1.72568 -11.71931,-7.26245 -3.66118,-2.75963 12.22594,4.45187 -8.56985,-6.25706 -12.39239,-6.11763 -11.85965,-3.27355 -26.14722,-6.68757 -38.68866,-4.80807 -16.65743,5.69366 -32.68639,13.16058 -47.93335,21.94478 16.45811,13.74259 32.83438,27.7034 47.35472,43.52603 0.46201,-1.33847 4.81877,-16.52447 2.98299,-7.17949 z m 1.63743,-0.76227 c 0.53748,-1.57602 0.24629,2.3148 0,0 z M 292.9154,683.2254 c -8.74431,-4.26628 -23.67496,-13.97889 -28.9772,-14.01741 7.58103,8.17003 20.16159,8.21787 29.14204,14.38725 l -0.16484,-0.36984 0,0 z m -31.50988,-8.64023 c 1.2711,-6.8894 -15.95382,-9.07564 -5.00816,-2.13743 1.37533,0.99824 6.15144,9.78646 5.00816,2.13743 z m -14.20231,-3.45139 c -0.17725,-1.65593 -1.32236,1.84833 0,0 z m 14.26902,-4.06849 c -7.52912,0.10615 -5.38205,-1.10576 -1.89724,-1.61916 -13.79436,-4.93623 1.70938,9.06091 1.89724,1.61916 l 0,0 z m -11.86185,-1.70873 c -2.07868,-2.09582 -0.18525,1.76321 0,0 z m -2.53053,-1.28271 c -3.22848,-6.11258 -11.71577,-14.40164 -18.58985,-10.13999 -11.4656,6.17684 8.26659,6.35364 12.6677,8.8956 1.95267,0.50184 3.91247,1.02312 5.92215,1.24439 z m -8.30174,-5.21665 c -2.86164,-2.59515 5.79372,3.17648 0,0 z m -4.21255,-2.66214 c -6.37991,-4.43339 7.05735,3.81591 0,0 z m 18.41767,7.51566 c 0.0934,-6.49593 -5.76721,2.26367 0,0 z m -3.7199,-1.75469 c -4.47638,-6.82752 -6.36758,-1.20861 -0.05,1.38516 l 0.05,-1.38516 z m -113.99276,-8.23624 c 12.9385,-6.28863 26.00173,-12.52556 39.85629,-16.54857 -13.21028,-1.91826 -26.41394,-3.95531 -39.71384,-5.16011 -0.74101,8.42675 -7.96464,21.55759 -8.01633,26.08545 2.4242,-1.7984 5.23915,-2.93937 7.87388,-4.37677 z"
-       style="fill:#000000" />
+       id="path4179"
+       inkscape:connector-curvature="0" />
     <g
-       inkscape:label="Layer 1"
+       transform="matrix(0.75951024,0,0,0.75951024,122.93855,481.02285)"
        id="layer1-88"
-       transform="matrix(0.75951024,0,0,0.75951024,122.93855,481.02285)">
+       inkscape:label="Layer 1">
       <ellipse
-         style="opacity:1;fill:#ffffff;fill-opacity:0;fill-rule:nonzero;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4133"
-         cx="422.00668"
+         ry="144.4816"
+         rx="29.498327"
          cy="340.79028"
-         rx="29.498327"
-         ry="144.4816" />
+         cx="422.00668"
+         id="path4133"
+         style="opacity:1;fill:#ffffff;fill-opacity:0;fill-rule:nonzero;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
     <g
-       inkscape:label="Layer 1"
+       transform="matrix(0.75951024,0,0,0.75951024,61.183451,484.85895)"
        id="layer1-04"
-       transform="matrix(0.75951024,0,0,0.75951024,61.183451,484.85895)">
+       inkscape:label="Layer 1">
       <g
-         id="g4238"
+         transform="translate(13.131983,-5.0507627)"
          style="stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
-         transform="translate(13.131983,-5.0507627)">
+         id="g4238">
         <ellipse
-           ry="144.4816"
-           rx="29.498327"
-           cy="340.79028"
-           cx="422.00668"
+           style="opacity:1;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="path4133-7"
-           style="opacity:1;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           cx="422.00668"
+           cy="340.79028"
+           rx="29.498327"
+           ry="144.4816" />
         <path
-           transform="translate(390.50836,194.30869)"
-           inkscape:connector-curvature="0"
-           id="path4236"
+           style="fill:#333333;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="M 26.965266,285.57268 C 21.130891,279.12577 13.564147,253.94733 10.059251,229.31771 6.2328997,202.42915 5.1503874,184.12767 5.1453433,146.24079 5.1391297,99.57003 7.4908428,72.296903 14.21108,41.104239 18.570164,20.871108 26.170577,4.7692174 31.361935,4.7692174 c 2.475986,0 7.66111,6.1849486 10.232181,12.2052086 23.596536,55.252186 21.429451,225.930084 -3.364925,265.018874 -3.97717,6.27008 -7.745247,7.46748 -11.263925,3.57938 z"
-           style="fill:#333333;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           id="path4236"
+           inkscape:connector-curvature="0"
+           transform="translate(390.50836,194.30869)" />
+      </g>
+    </g>
+    <g
+       transform="matrix(0.75951024,0,0,0.75951024,229.1925,530.89224)"
+       id="layer1-75"
+       inkscape:label="Layer 1">
+      <ellipse
+         ry="144.4816"
+         rx="29.498327"
+         cy="275.13034"
+         cx="350.28586"
+         id="path4133-4"
+         style="opacity:1;fill:url(#linearGradient4167);fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       inkscape:label="Layer 1"
+       id="layer1-26"
+       transform="translate(112.35028,73.355541)">
+      <g
+         id="g4271-6"
+         transform="matrix(0.70710678,-0.70710678,0.70710678,0.70710678,-216.8875,351.66629)">
+        <rect
+           transform="matrix(0.70600487,-0.70820697,0.70600487,0.70820697,0,0)"
+           y="530.37567"
+           x="-187.93834"
+           height="4.806571"
+           width="205.65259"
+           id="rect4145-7"
+           style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999785;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4293-8"
+           d="m 390.34762,366.47444 -2.21123,24.43028"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4295-7"
+           d="M 388.13639,390.90472 267.37357,512.5646"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4170-6"
+           d="m 255.13747,511.67922 c -4.83857,-0.10225 -7.7582,-0.27692 -7.76954,-0.46482 -0.033,-0.54705 141.93887,-142.76892 142.00797,-142.258 0.0361,0.26699 -0.37024,5.23929 -0.90301,11.04957 l -0.96867,10.56413 -60.20067,60.62316 -60.20067,60.62315 -2.10702,0.0133 c -1.15886,0.007 -5.59514,-0.0604 -9.85839,-0.1505 l 0,10e-6 z"
+           style="fill:url(#radialGradient4190-0);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4269-7"
+           d="m 245.15589,512.11904 21.94699,-0.30263"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
       </g>
     </g>
     <g
        inkscape:label="Layer 1"
-       id="layer1-75"
-       transform="matrix(0.75951024,0,0,0.75951024,229.1925,530.89224)">
-      <ellipse
-         style="opacity:1;fill:url(#linearGradient4167);fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path4133-4"
-         cx="350.28586"
-         cy="275.13034"
-         rx="29.498327"
-         ry="144.4816" />
-    </g>
-    <g
-       transform="translate(112.35028,73.355541)"
-       id="layer1-26"
-       inkscape:label="Layer 1">
-      <g
-         transform="matrix(0.70710678,-0.70710678,0.70710678,0.70710678,-216.8875,351.66629)"
-         id="g4271-6">
-        <rect
-           style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999785;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="rect4145-7"
-           width="205.65259"
-           height="4.806571"
-           x="-187.93834"
-           y="530.37567"
-           transform="matrix(0.70600487,-0.70820697,0.70600487,0.70820697,0,0)" />
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 390.34762,366.47444 -2.21123,24.43028"
-           id="path4293-8"
-           inkscape:connector-curvature="0" />
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="M 388.13639,390.90472 267.37357,512.5646"
-           id="path4295-7"
-           inkscape:connector-curvature="0" />
-        <path
-           style="fill:url(#radialGradient4190-0);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           d="m 255.13747,511.67922 c -4.83857,-0.10225 -7.7582,-0.27692 -7.76954,-0.46482 -0.033,-0.54705 141.93887,-142.76892 142.00797,-142.258 0.0361,0.26699 -0.37024,5.23929 -0.90301,11.04957 l -0.96867,10.56413 -60.20067,60.62316 -60.20067,60.62315 -2.10702,0.0133 c -1.15886,0.007 -5.59514,-0.0604 -9.85839,-0.1505 l 0,10e-6 z"
-           id="path4170-6"
-           inkscape:connector-curvature="0" />
-        <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 245.15589,512.11904 21.94699,-0.30263"
-           id="path4269-7"
-           inkscape:connector-curvature="0" />
-      </g>
-    </g>
-    <g
-       transform="translate(267.81316,-43.868154)"
        id="layer1-798"
-       inkscape:label="Layer 1">
+       transform="translate(267.81316,-43.868154)">
       <g
          id="g4211">
         <rect
-           style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999785;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="rect4145-9"
-           width="205.65259"
-           height="4.806571"
-           x="-187.93834"
+           transform="matrix(0.70600487,-0.70820697,0.70600487,0.70820697,0,0)"
            y="530.37567"
-           transform="matrix(0.70600487,-0.70820697,0.70600487,0.70820697,0,0)" />
-        <rect
-           style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999785;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="rect4145-6-6"
-           width="205.65259"
+           x="-187.93834"
            height="4.806571"
-           x="-741.17816"
+           width="205.65259"
+           id="rect4145-9"
+           style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999785;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <rect
+           transform="matrix(-0.70600487,-0.70820697,0.70600487,-0.70820697,0,0)"
            y="-193.08824"
-           transform="matrix(-0.70600487,-0.70820697,0.70600487,-0.70820697,0,0)" />
+           x="-741.17816"
+           height="4.806571"
+           width="205.65259"
+           id="rect4145-6-6"
+           style="opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999785;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 390.34762,366.47444 -2.21123,24.43028"
+           inkscape:connector-curvature="0"
            id="path4293-1"
-           inkscape:connector-curvature="0" />
+           d="m 390.34762,366.47444 -2.21123,24.43028"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
         <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="M 388.13639,390.90472 267.37357,512.5646"
+           inkscape:connector-curvature="0"
            id="path4295-9"
-           inkscape:connector-curvature="0" />
+           d="M 388.13639,390.90472 267.37357,512.5646"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
         <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="M 390.34761,658.24993 388.1364,633.81961"
+           inkscape:connector-curvature="0"
            id="path4297-8"
-           inkscape:connector-curvature="0" />
+           d="M 390.34761,658.24993 388.1364,633.81961"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
         <path
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="M 388.1364,633.81961 267.37357,512.5646 245.15589,512.11904"
+           inkscape:connector-curvature="0"
            id="path4299-0"
-           inkscape:connector-curvature="0" />
+           d="M 388.1364,633.81961 267.37357,512.5646 245.15589,512.11904"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
         <path
-           style="fill:url(#radialGradient4188);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           d="m 76.736673,222.10541 -71.459441,-71.68746 10.328685,0.21846 10.328685,0.21847 43.387449,43.54716 c 23.863097,23.95094 50.992559,51.20017 60.287689,60.55385 l 16.90024,17.00669 0.95806,10.80015 c 0.52693,5.94008 0.90632,10.8519 0.84307,10.91514 -0.0633,0.0633 -32.27175,-32.14436 -71.574437,-71.57246 z"
+           transform="translate(241.05642,362.36219)"
+           inkscape:connector-curvature="0"
            id="path4168"
-           inkscape:connector-curvature="0"
-           transform="translate(241.05642,362.36219)" />
+           d="m 76.736673,222.10541 -71.459441,-71.68746 10.328685,0.21846 10.328685,0.21847 43.387449,43.54716 c 23.863097,23.95094 50.992559,51.20017 60.287689,60.55385 l 16.90024,17.00669 0.95806,10.80015 c 0.52693,5.94008 0.90632,10.8519 0.84307,10.91514 -0.0633,0.0633 -32.27175,-32.14436 -71.574437,-71.57246 z"
+           style="fill:url(#radialGradient4188);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
         <path
-           style="fill:url(#radialGradient4190-5);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           d="M 14.081049,149.31703 C 9.2424779,149.21478 6.3228524,149.04011 6.3115077,148.85221 6.2784772,148.30516 148.25038,6.0832944 148.31948,6.5942119 148.35559,6.861196 147.94924,11.8335 147.41647,17.643776 l -0.96867,10.564138 -60.200668,60.623152 -60.200669,60.623154 -2.107024,0.0133 c -1.158862,0.007 -5.595138,-0.0604 -9.85839,-0.1505 l 0,10e-6 z"
-           id="path4170-4"
+           transform="translate(241.05642,362.36219)"
            inkscape:connector-curvature="0"
-           transform="translate(241.05642,362.36219)" />
+           id="path4170-4"
+           d="M 14.081049,149.31703 C 9.2424779,149.21478 6.3228524,149.04011 6.3115077,148.85221 6.2784772,148.30516 148.25038,6.0832944 148.31948,6.5942119 148.35559,6.861196 147.94924,11.8335 147.41647,17.643776 l -0.96867,10.564138 -60.200668,60.623152 -60.200669,60.623154 -2.107024,0.0133 c -1.158862,0.007 -5.595138,-0.0604 -9.85839,-0.1505 l 0,10e-6 z"
+           style="fill:url(#radialGradient4190-5);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
       </g>
     </g>
+    <g
+       transform="matrix(0.71277395,0,0,0.8325601,13.69943,903.54747)"
+       id="g929">
+      <rect
+         style="fill:#030303;fill-opacity:1;fill-rule:nonzero;stroke:#fcfcfc;stroke-width:0.179748;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect23"
+         width="67.488998"
+         height="30.711918"
+         x="14.80654"
+         y="12.954457" />
+      <rect
+         y="-43.675724"
+         x="20.095764"
+         height="30.691668"
+         width="83.60833"
+         id="rect23-0"
+         style="fill:#030303;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:14.465;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         transform="rotate(90.055511)" />
+      <rect
+         y="97.850571"
+         x="13.026617"
+         height="13.660525"
+         width="38.343102"
+         id="rect23-9"
+         style="fill:#030303;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:6.53521;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         style="fill:#030303;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.69497;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect23-9-5"
+         width="27.043755"
+         height="1.3028469"
+         x="15.185413"
+         y="116.95586" />
+    </g>
+    <g
+       transform="matrix(0.91516583,0,0,0.91542645,-18.245553,770.88676)"
+       id="g2921">
+      <rect
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.227386;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect23-9-3"
+         width="39.417328"
+         height="9.4924593"
+         x="115.87746"
+         y="244.01312" />
+      <rect
+         transform="matrix(-0.00125333,0.99999921,-0.99999972,-7.4894233e-4,0,0)"
+         style="mix-blend-mode:normal;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.341079;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect23-0-1"
+         width="83.575539"
+         height="39.687885"
+         x="166.2509"
+         y="-153.3533" />
+      <rect
+         y="254.58101"
+         x="117.39637"
+         height="1.3028469"
+         width="27.043756"
+         id="rect23-9-5-2"
+         style="fill:#fbfbfb;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="157.85223"
+         x="121.8755"
+         height="30.711918"
+         width="67.488998"
+         id="rect23-2"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;image-rendering:auto" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.312005;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect2885"
+         width="37.207401"
+         height="7.7966042"
+         x="116.17866"
+         y="244.11134"
+         ry="0" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.226342px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="path2889"
+         sodipodi:type="arc"
+         sodipodi:cx="173.30241"
+         sodipodi:cy="-123.05588"
+         sodipodi:rx="15.364689"
+         sodipodi:ry="12.851066"
+         sodipodi:start="0"
+         sodipodi:end="3.1346296"
+         sodipodi:arc-type="arc"
+         d="m 188.6671,-123.05588 a 15.364689,12.851066 0 0 1 -15.31119,12.85099 15.364689,12.851066 0 0 1 -15.41781,-12.76151"
+         sodipodi:open="true"
+         transform="matrix(0.00177067,0.99999843,-0.99999856,0.00169672,0,0)" />
+    </g>
+    <g
+       transform="matrix(3.5433071,0,0,3.5433071,207.08442,687.45347)"
+       id="g3019">
+      <rect
+         y="66.028557"
+         x="41.707031"
+         height="19.858885"
+         width="36.322685"
+         id="rect2959-3"
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.172514;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:#0a0000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="path2976"
+         sodipodi:type="arc"
+         sodipodi:cx="75.812561"
+         sodipodi:cy="-89.531181"
+         sodipodi:rx="13.657473"
+         sodipodi:ry="17.591871"
+         sodipodi:start="0"
+         sodipodi:end="3.1346288"
+         sodipodi:open="true"
+         sodipodi:arc-type="arc"
+         d="M 89.470034,-89.531181 A 13.657473,17.591871 0 0 1 75.860115,-71.939417 13.657473,17.591871 0 0 1 62.15542,-89.408675"
+         transform="matrix(-3.6055152e-4,0.99999994,-0.99999995,-3.0160269e-4,0,0)" />
+    </g>
+    <g
+       transform="matrix(3.5433071,0,0,3.5433071,10.795359,535.84214)"
+       id="g3015">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.172514;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect2959-3-8"
+         width="36.322685"
+         height="19.858885"
+         x="42.750725"
+         y="108.80307" />
+      <path
+         transform="matrix(-3.6055036e-4,0.99999994,-0.99999995,-3.0160383e-4,0,0)"
+         d="M 132.24422,-90.590302 A 13.657473,17.591871 0 0 1 118.6343,-72.998537 13.657473,17.591871 0 0 1 104.9296,-90.467795 Z"
+         sodipodi:arc-type="chord"
+         sodipodi:open="true"
+         sodipodi:end="3.1346288"
+         sodipodi:start="0"
+         sodipodi:ry="17.591871"
+         sodipodi:rx="13.657473"
+         sodipodi:cy="-90.590302"
+         sodipodi:cx="118.58675"
+         sodipodi:type="arc"
+         id="path2976-6"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+    <rect
+       ry="0"
+       y="922.19952"
+       x="251.43262"
+       height="68.400635"
+       width="42.426407"
+       id="rect3011"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.708662;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/strobes/monolights.svg
+++ b/strobes/monolights.svg
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="monolights.svg"
+   inkscape:version="1.0beta2 (unknown)"
+   id="svg21"
+   version="1.1"
+   viewBox="0 0 210 297"
+   height="297mm"
+   width="210mm">
+  <defs
+     id="defs15">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient2881">
+      <stop
+         id="stop2879"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient933">
+      <stop
+         id="stop931"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     inkscape:window-maximized="1"
+     inkscape:window-y="0"
+     inkscape:window-x="1920"
+     inkscape:window-height="1411"
+     inkscape:window-width="2560"
+     inkscape:object-nodes="false"
+     inkscape:snap-bbox="false"
+     showgrid="false"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="370.9167"
+     inkscape:cx="364.8688"
+     inkscape:zoom="2.8284271"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata18">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <g
+       id="g3019">
+      <rect
+         y="66.028557"
+         x="41.707031"
+         height="19.858885"
+         width="36.322685"
+         id="rect2959-3"
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.172514;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:#0a0000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="path2976"
+         sodipodi:type="arc"
+         sodipodi:cx="75.812561"
+         sodipodi:cy="-89.531181"
+         sodipodi:rx="13.657473"
+         sodipodi:ry="17.591871"
+         sodipodi:start="0"
+         sodipodi:end="3.1346288"
+         sodipodi:open="true"
+         sodipodi:arc-type="arc"
+         d="M 89.470034,-89.531181 A 13.657473,17.591871 0 0 1 75.860115,-71.939417 13.657473,17.591871 0 0 1 62.15542,-89.408675"
+         transform="matrix(-3.6055152e-4,0.99999994,-0.99999995,-3.0160269e-4,0,0)" />
+    </g>
+    <g
+       id="g3015">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.172514;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect2959-3-8"
+         width="36.322685"
+         height="19.858885"
+         x="42.750725"
+         y="108.80307" />
+      <path
+         transform="matrix(-3.6055036e-4,0.99999994,-0.99999995,-3.0160383e-4,0,0)"
+         d="M 132.24422,-90.590302 A 13.657473,17.591871 0 0 1 118.6343,-72.998537 13.657473,17.591871 0 0 1 104.9296,-90.467795 Z"
+         sodipodi:arc-type="chord"
+         sodipodi:open="true"
+         sodipodi:end="3.1346288"
+         sodipodi:start="0"
+         sodipodi:ry="17.591871"
+         sodipodi:rx="13.657473"
+         sodipodi:cy="-90.590302"
+         sodipodi:cx="118.58675"
+         sodipodi:type="arc"
+         id="path2976-6"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+    <rect
+       ry="0"
+       y="109.03864"
+       x="67.913185"
+       height="19.304178"
+       width="11.973675"
+       id="rect3011"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/strobes/speedlights.svg
+++ b/strobes/speedlights.svg
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="speedlights.svg"
+   inkscape:version="1.0beta2 (unknown)"
+   id="svg21"
+   version="1.1"
+   viewBox="0 0 210 297"
+   height="297mm"
+   width="210mm">
+  <defs
+     id="defs15">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient2881">
+      <stop
+         id="stop2879"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient933">
+      <stop
+         id="stop931"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     inkscape:window-maximized="1"
+     inkscape:window-y="0"
+     inkscape:window-x="1920"
+     inkscape:window-height="1411"
+     inkscape:window-width="2560"
+     inkscape:object-nodes="false"
+     inkscape:snap-bbox="false"
+     showgrid="false"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="636.29368"
+     inkscape:cx="431.61879"
+     inkscape:zoom="1.4142136"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata18">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <g
+       id="g929">
+      <rect
+         style="fill:#030303;fill-opacity:1;fill-rule:nonzero;stroke:#fcfcfc;stroke-width:0.179748;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect23"
+         width="67.488998"
+         height="30.711918"
+         x="14.80654"
+         y="12.954457" />
+      <rect
+         y="-43.675724"
+         x="20.095764"
+         height="30.691668"
+         width="83.60833"
+         id="rect23-0"
+         style="fill:#030303;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:14.465;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         transform="rotate(90.055511)" />
+      <rect
+         y="97.850571"
+         x="13.026617"
+         height="13.660525"
+         width="38.343102"
+         id="rect23-9"
+         style="fill:#030303;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:6.53521;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         style="fill:#030303;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.69497;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect23-9-5"
+         width="27.043755"
+         height="1.3028469"
+         x="15.185413"
+         y="116.95586" />
+    </g>
+    <g
+       id="g2921">
+      <rect
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.227386;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect23-9-3"
+         width="39.417328"
+         height="9.4924593"
+         x="115.87746"
+         y="244.01312" />
+      <rect
+         transform="matrix(-0.00125333,0.99999921,-0.99999972,-7.4894233e-4,0,0)"
+         style="mix-blend-mode:normal;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.341079;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect23-0-1"
+         width="83.575539"
+         height="39.687885"
+         x="166.2509"
+         y="-153.3533" />
+      <rect
+         y="254.58101"
+         x="117.39637"
+         height="1.3028469"
+         width="27.043756"
+         id="rect23-9-5-2"
+         style="fill:#fbfbfb;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="157.85223"
+         x="121.8755"
+         height="30.711918"
+         width="67.488998"
+         id="rect23-2"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;image-rendering:auto" />
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.312005;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect2885"
+         width="37.207401"
+         height="7.7966042"
+         x="116.17866"
+         y="244.11134"
+         ry="0" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.226342px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="path2889"
+         sodipodi:type="arc"
+         sodipodi:cx="173.30241"
+         sodipodi:cy="-123.05588"
+         sodipodi:rx="15.364689"
+         sodipodi:ry="12.851066"
+         sodipodi:start="0"
+         sodipodi:end="3.1346296"
+         sodipodi:arc-type="arc"
+         d="m 188.6671,-123.05588 a 15.364689,12.851066 0 0 1 -15.31119,12.85099 15.364689,12.851066 0 0 1 -15.41781,-12.76151"
+         sodipodi:open="true"
+         transform="matrix(0.00177067,0.99999843,-0.99999856,0.00169672,0,0)" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
For the speedlight added a black and a white version in case someone wants to put their strobe on top of the softbox or octolight to show that it's inside.

Also fixed readme to add a link to a professional using a lighting diagram, changed the order of the text to be more user-focused, and modified Contributing to no longer need strobes.